### PR TITLE
Library sync between devices, and a folder picker for on-device music

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -86,6 +86,13 @@ flutter {
 }
 
 dependencies {
+    // ── Library sync ─────────────────────────────────────────────────────
+    // DocumentFile wraps the Storage Access Framework's tree API, which is
+    // otherwise raw ContentResolver calls against DocumentsContract. AndroidX,
+    // free software, and small — the alternative is hand-rolling directory
+    // listing and file creation over a provider we do not control.
+    implementation("androidx.documentfile:documentfile:1.0.1")
+
     // ── YouTube Music tier ───────────────────────────────────────────────
     // InnerTube extraction (client ladder, cipher/n-transform, format
     // selection, self-healing remote player configs) from the Metrolist

--- a/android/app/src/main/kotlin/codes/afk/sunoh/MainActivity.kt
+++ b/android/app/src/main/kotlin/codes/afk/sunoh/MainActivity.kt
@@ -1,10 +1,13 @@
 package codes.afk.sunoh
 
+import android.content.Intent
 import codes.afk.sunoh.localmedia.LocalMediaBridge
+import codes.afk.sunoh.sync.SyncBridge
 import codes.afk.sunoh.ytmusic.YtMusicBridge
 import com.ryanheise.audioservice.AudioServiceActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.Result
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -30,6 +33,21 @@ class MainActivity : AudioServiceActivity() {
      * so a destroyed activity cancels an in-flight scan.
      */
     private val localScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Scope for sync file I/O. Separate again: a folder behind a cloud
+     * provider can block for seconds on a cold read, and that must not sit in
+     * front of stream resolution or a library scan.
+     */
+    private val syncScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    /**
+     * Held across the folder picker. SAF answers through onActivityResult, so
+     * the Dart call is parked until the user has chosen, or backed out — which
+     * returns null rather than an error, because cancelling a picker is a
+     * normal thing to do.
+     */
+    private var pendingFolderResult: Result? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -108,10 +126,133 @@ class MainActivity : AudioServiceActivity() {
                     else -> result.notImplemented()
                 }
             }
+
+        // Library sync: folder access and encryption. No network here. The app
+        // writes an encrypted file into a folder the user picked, and whatever
+        // syncs that folder does the moving.
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, SYNC_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "pickFolder" -> {
+                        if (pendingFolderResult != null) {
+                            result.error("busy", "picker already open", null)
+                        } else {
+                            pendingFolderResult = result
+                            startActivityForResult(
+                                SyncBridge.openFolderPickerIntent(),
+                                SyncBridge.PICK_FOLDER_REQUEST,
+                            )
+                        }
+                    }
+
+                    "hasAccess" -> {
+                        val tree = call.argument<String>("tree")
+                        result.success(
+                            tree != null && SyncBridge.hasAccess(applicationContext, tree),
+                        )
+                    }
+
+                    "folderName" -> {
+                        val tree = call.argument<String>("tree")
+                        result.success(
+                            tree?.let { SyncBridge.folderName(applicationContext, it) },
+                        )
+                    }
+
+                    "generateKey" -> result.success(SyncBridge.generateKey())
+
+                    "readAll" -> {
+                        val tree = call.argument<String>("tree")
+                        val key = call.argument<String>("key")
+                        if (tree == null || key == null) {
+                            result.error("bad_args", "tree and key required", null)
+                            return@setMethodCallHandler
+                        }
+                        syncScope.launch {
+                            val outcome = runCatching {
+                                SyncBridge.readAll(applicationContext, tree)
+                                    .mapNotNull { (name, bytes) ->
+                                        // A file encrypted with another key is
+                                        // skipped, not an error: the folder may
+                                        // be shared with a different setup.
+                                        SyncBridge.decrypt(bytes, key)?.let { name to it }
+                                    }
+                                    .toMap()
+                            }
+                            withContext(Dispatchers.Main) {
+                                outcome.onSuccess { result.success(it) }
+                                    .onFailure {
+                                        result.error(
+                                            "read_failed",
+                                            it.message ?: "read failed",
+                                            null,
+                                        )
+                                    }
+                            }
+                        }
+                    }
+
+                    "write" -> {
+                        val tree = call.argument<String>("tree")
+                        val name = call.argument<String>("name")
+                        val key = call.argument<String>("key")
+                        val bytes = call.argument<ByteArray>("bytes")
+                        if (tree == null || name == null || key == null || bytes == null) {
+                            result.error("bad_args", "missing argument", null)
+                            return@setMethodCallHandler
+                        }
+                        syncScope.launch {
+                            val outcome = runCatching {
+                                val blob = SyncBridge.encrypt(bytes, key)
+                                if (blob == null) false
+                                else SyncBridge.write(applicationContext, tree, name, blob)
+                            }
+                            withContext(Dispatchers.Main) {
+                                outcome.onSuccess { result.success(it) }
+                                    .onFailure {
+                                        result.error(
+                                            "write_failed",
+                                            it.message ?: "write failed",
+                                            null,
+                                        )
+                                    }
+                            }
+                        }
+                    }
+
+                    "delete" -> {
+                        val tree = call.argument<String>("tree")
+                        val name = call.argument<String>("name")
+                        result.success(
+                            tree != null && name != null &&
+                                SyncBridge.delete(applicationContext, tree, name),
+                        )
+                    }
+
+                    else -> result.notImplemented()
+                }
+            }
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        if (requestCode == SyncBridge.PICK_FOLDER_REQUEST) {
+            val pending = pendingFolderResult
+            pendingFolderResult = null
+            val uri = SyncBridge.treeUriFromResult(resultCode, data)
+            if (uri == null) {
+                pending?.success(null)
+            } else {
+                SyncBridge.persistTreePermission(applicationContext, uri)
+                pending?.success(uri.toString())
+            }
+            return
+        }
+        super.onActivityResult(requestCode, resultCode, data)
     }
 
     private companion object {
         const val CHANNEL = "codes.afk.sunoh/ytmusic"
         const val LOCAL_CHANNEL = "codes.afk.sunoh/localmedia"
+        const val SYNC_CHANNEL = "codes.afk.sunoh/sync"
     }
 }

--- a/android/app/src/main/kotlin/codes/afk/sunoh/sync/SyncBridge.kt
+++ b/android/app/src/main/kotlin/codes/afk/sunoh/sync/SyncBridge.kt
@@ -1,0 +1,227 @@
+package codes.afk.sunoh.sync
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.DocumentsContract
+import android.util.Base64
+import android.util.Log
+import androidx.documentfile.provider.DocumentFile
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Folder access and encryption for library sync.
+ *
+ * ## Why this is native
+ *
+ * Two reasons, both the same reason the YouTube and MediaStore bridges are.
+ *
+ * The Storage Access Framework has no Flutter equivalent worth depending on:
+ * picking a tree, persisting the permission across reboots, and enumerating a
+ * folder are all ContentResolver work, and the available pub wrappers have the
+ * maintenance record `pubspec.yaml` already documents for one package.
+ *
+ * AES-GCM is in the platform via javax.crypto. Reaching for a pub crypto
+ * package would add a dependency for something the OS already does, and
+ * dependency count is not free while F-Droid inclusion is still open.
+ *
+ * ## What it does not do
+ *
+ * No network, no account, no Google API. The app writes an encrypted file into
+ * a folder the user picked; whatever syncs that folder does the moving. sunoh
+ * never learns where the folder actually lives.
+ */
+object SyncBridge {
+    private const val TAG = "SyncBridge"
+
+    /** AES-128-GCM. 128 bits keeps the recovery code short enough to type. */
+    private const val KEY_BITS = 128
+    private const val GCM_TAG_BITS = 128
+    private const val IV_BYTES = 12
+
+    /** Marks our files so a shared folder can hold other things safely. */
+    const val FILE_PREFIX = "sunoh-"
+    const val FILE_SUFFIX = ".sync"
+
+    private const val MIME = "application/octet-stream"
+
+    fun openFolderPickerIntent(): Intent =
+        Intent(Intent.ACTION_OPEN_DOCUMENT_TREE).apply {
+            addFlags(
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                    Intent.FLAG_GRANT_WRITE_URI_PERMISSION or
+                    Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION,
+            )
+        }
+
+    /**
+     * Take a long-lived grant on the picked tree.
+     *
+     * Without this the permission dies with the process and the user is asked
+     * to re-pick the folder on every launch.
+     */
+    fun persistTreePermission(context: Context, uri: Uri): Boolean = try {
+        context.contentResolver.takePersistableUriPermission(
+            uri,
+            Intent.FLAG_GRANT_READ_URI_PERMISSION or
+                Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+        )
+        true
+    } catch (e: SecurityException) {
+        Log.w(TAG, "could not persist permission for $uri: ${e.message}")
+        false
+    }
+
+    /** True while the saved tree is still readable — the user can revoke it. */
+    fun hasAccess(context: Context, treeUri: String): Boolean = try {
+        val tree = DocumentFile.fromTreeUri(context, Uri.parse(treeUri))
+        tree != null && tree.exists() && tree.canWrite()
+    } catch (e: Exception) {
+        false
+    }
+
+    /** A display name for the folder, for the settings row. */
+    fun folderName(context: Context, treeUri: String): String? = try {
+        DocumentFile.fromTreeUri(context, Uri.parse(treeUri))?.name
+    } catch (e: Exception) {
+        null
+    }
+
+    /**
+     * Every sync file in the folder, as `name -> bytes`.
+     *
+     * Reads *all* of them, including this device's own: each device writes only
+     * its own file, so a full read is how the merge sees the others. Files that
+     * fail to open are skipped rather than failing the sync — a half-synced
+     * cloud folder is normal, not exceptional.
+     */
+    fun readAll(context: Context, treeUri: String): Map<String, ByteArray> {
+        val out = HashMap<String, ByteArray>()
+        val tree = DocumentFile.fromTreeUri(context, Uri.parse(treeUri))
+            ?: return out
+        for (file in tree.listFiles()) {
+            val name = file.name ?: continue
+            if (!name.startsWith(FILE_PREFIX) || !name.endsWith(FILE_SUFFIX)) {
+                continue
+            }
+            try {
+                context.contentResolver.openInputStream(file.uri)?.use {
+                    out[name] = it.readBytes()
+                }
+            } catch (e: Exception) {
+                Log.w(TAG, "skipping unreadable $name: ${e.message}")
+            }
+        }
+        Log.i(TAG, "read ${out.size} sync file(s)")
+        return out
+    }
+
+    /**
+     * Write this device's file, replacing what was there.
+     *
+     * Deletes and recreates rather than truncating: SAF's write mode "w" does
+     * not reliably truncate across providers, which leaves the tail of a longer
+     * previous document appended to a shorter new one — corrupt JSON that only
+     * appears once a library shrinks.
+     */
+    fun write(
+        context: Context,
+        treeUri: String,
+        name: String,
+        bytes: ByteArray,
+    ): Boolean {
+        return try {
+            val tree = DocumentFile.fromTreeUri(context, Uri.parse(treeUri))
+                ?: return false
+            tree.findFile(name)?.delete()
+            val file = tree.createFile(MIME, name) ?: return false
+            context.contentResolver.openOutputStream(file.uri, "w")?.use {
+                it.write(bytes)
+                it.flush()
+            } ?: return false
+            Log.i(TAG, "wrote $name (${bytes.size} bytes)")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "write failed for $name: ${e.message}")
+            false
+        }
+    }
+
+    /** Remove this device's own file, for "stop syncing and clean up". */
+    fun delete(context: Context, treeUri: String, name: String): Boolean = try {
+        DocumentFile.fromTreeUri(context, Uri.parse(treeUri))
+            ?.findFile(name)?.delete() ?: false
+    } catch (e: Exception) {
+        false
+    }
+
+    // ── Encryption ───────────────────────────────────────────────────────
+
+    /** A fresh random key, base64 for storage. */
+    fun generateKey(): String {
+        val key = ByteArray(KEY_BITS / 8)
+        SecureRandom().nextBytes(key)
+        return Base64.encodeToString(key, Base64.NO_WRAP)
+    }
+
+    /**
+     * AES-GCM, IV prepended to the ciphertext.
+     *
+     * A fresh random IV per write matters more than usual here: the same
+     * library is re-encrypted on every change, so a fixed IV would leak which
+     * parts changed between two versions of the file sitting in the cloud.
+     */
+    fun encrypt(plain: ByteArray, keyB64: String): ByteArray? = try {
+        val key = SecretKeySpec(Base64.decode(keyB64, Base64.NO_WRAP), "AES")
+        val iv = ByteArray(IV_BYTES).also { SecureRandom().nextBytes(it) }
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+        iv + cipher.doFinal(plain)
+    } catch (e: Exception) {
+        Log.e(TAG, "encrypt failed: ${e.message}")
+        null
+    }
+
+    /**
+     * Returns null when the file was written with a different key, or is
+     * truncated or corrupt. GCM authenticates, so a wrong key is a clean
+     * failure rather than garbage output — which is what lets the caller say
+     * "this folder belongs to a different setup" instead of importing rubbish.
+     */
+    fun decrypt(blob: ByteArray, keyB64: String): ByteArray? = try {
+        if (blob.size <= IV_BYTES) {
+            null
+        } else {
+            val key = SecretKeySpec(Base64.decode(keyB64, Base64.NO_WRAP), "AES")
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                key,
+                GCMParameterSpec(GCM_TAG_BITS, blob.copyOfRange(0, IV_BYTES)),
+            )
+            cipher.doFinal(blob.copyOfRange(IV_BYTES, blob.size))
+        }
+    } catch (e: Exception) {
+        // Expected whenever the key does not match; not worth an error log.
+        Log.i(TAG, "decrypt failed (wrong key or corrupt file)")
+        null
+    }
+
+    /** Request code for the folder picker, matched in onActivityResult. */
+    const val PICK_FOLDER_REQUEST = 0x5117
+
+    fun treeUriFromResult(resultCode: Int, data: Intent?): Uri? =
+        if (resultCode == Activity.RESULT_OK) data?.data else null
+
+    /** Only used for logging; a tree uri is long and mostly opaque. */
+    fun shortUri(uri: String): String =
+        try {
+            Uri.decode(DocumentsContract.getTreeDocumentId(Uri.parse(uri)))
+        } catch (e: Exception) {
+            uri.takeLast(24)
+        }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -47,6 +47,7 @@ Companion documents:
 | `lib/router/` | `go_router` config, nav extension, deep-link dispatch. |
 | `lib/screens/` `lib/overlays/` `lib/player/` `lib/shell/` | UI. |
 | `lib/services/` | Update checker. |
+| `lib/sync/` | Library sync across devices via a user-picked folder. See [`SYNC.md`](SYNC.md). |
 | `lib/state/` | `AppState` — the player and library state machine. |
 | `lib/theme/` | Design tokens, light and dark. The only place raw colours are defined. |
 | `lib/widgets/` | Shared, screen-agnostic widgets. |

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -1,0 +1,154 @@
+# Library sync
+
+Keeping liked songs, playlists and settings the same across two phones, with
+no account, no server of ours, and no cloud SDK in the app.
+
+The app writes an encrypted file into a folder the user picks with the system
+picker. Whatever syncs that folder — Syncthing, Nextcloud, a Drive folder —
+moves it. sunoh never learns where the folder actually lives.
+
+---
+
+## Why not a cloud API
+
+Google Drive sync means the Drive REST API, which means Google Sign-In, which
+means Google Play Services. That would contradict "No account. No sign-in,
+ever." in the README, the disclaimer and the store listing; add a second
+proprietary Google dependency immediately after removing one; and take F-Droid
+from a single removable blocker to two, one of which could never be removed if
+sync were a core feature.
+
+The Storage Access Framework gets the same outcome with none of that. The cost
+is that sync happens when the folder syncs rather than on our schedule, which
+for a music library is not a real cost.
+
+**Unverified:** whether Google Drive specifically can be picked as a tree. Its
+Android provider has historically been poor at `OPEN_DOCUMENT_TREE`. The design
+works regardless with any folder-syncing app; only "Drive" as the answer
+depends on it.
+
+---
+
+## One file per device
+
+Each device writes `sunoh-<deviceId>.sync` and reads **every** `.sync` file in
+the folder.
+
+This is the load-bearing decision. Two devices never write the same file, so
+there is no locking problem and no last-writer-clobbers — the failure mode
+every "one shared JSON in a cloud folder" design hits. A third device works for
+free, and a device joining later gets everything from whichever file it reads,
+because each file carries the merged state after its owner last synced.
+
+---
+
+## Merging
+
+`lib/sync/sync_merge.dart`. A collection is a set of records keyed by id, each
+carrying when it was last touched and whether that touch was an addition or a
+removal. Merging takes the newest record per id.
+
+**Deletions have to be represented, not merely absent.** Unliking a song on one
+phone removes it there; a union with the other phone puts it back, and it comes
+back on both. That tombstone is the reason the whole file exists.
+
+Rules worth knowing:
+
+- **Ties go to the deletion.** An earlier version kept "whichever record is
+  mine", so two devices merging the same pair reached opposite answers and
+  wrote both back, flipping an item's state forever. Ties are same-millisecond
+  coincidence; resurrection is the failure that matters.
+- **Items with no record survive.** That is a library from before sync existed.
+  Dropping it to fix a bookkeeping gap would be deleting the user's data to
+  tidy our own.
+- **Tombstones prune on a 90-day window.** They cannot be kept forever or
+  dropped eagerly: a device offline longer than the window still holds the
+  item, sees no tombstone, and re-adds it. The window is the honest statement
+  of how long a phone can be away and still have its deletions respected.
+- **Episode progress merges on furthest position**, not newest write. Resuming
+  earlier than you actually reached is the annoying failure; hearing a few
+  seconds twice is not.
+- **User playlists merge per playlist on `updatedAt`**, not per song. Per-song
+  merging needs a record per song per playlist and still would not know what to
+  do about order. Losing the older of two same-playlist edits is
+  understandable; a silently interleaved track order is not.
+
+Metadata sits **beside** the collections in the `library` box rather than
+inside them, so the stored shapes are exactly what they always were. Nothing
+needed migrating, and a build without sync reads the same data unchanged.
+
+---
+
+## What syncs
+
+Liked songs, saved albums, playlists and artists, user playlists, podcast
+subscriptions, episode progress, and the appearance and playback settings.
+
+**Deliberately excluded**, so it is a decision rather than an oversight:
+
+| Not synced | Why |
+|---|---|
+| Downloads | Entries hold absolute paths meaningless on another device, and the audio is far too large. A future version could sync the *intent* and let each device fetch its own copy. |
+| Playback queue and position | Per-device state. Syncing it makes two phones fight over what is playing. |
+| History | Nothing is ever explicitly removed from it, so it needs no tombstones. |
+| Search recents | A local convenience that carries what you typed. The last thing that should be copied into a shared folder. |
+
+Settings sync as one blob with a single timestamp rather than per key.
+Per-key merging needs a timestamp per key and a migration to add them, for a
+conflict that barely arises.
+
+---
+
+## Encryption
+
+AES-128-GCM, done natively in `SyncBridge.kt` with `javax.crypto`. A pub crypto
+package would add a dependency for something the platform already does, and
+dependency count is not free while F-Droid inclusion is open.
+
+The key is generated once, shown to the user as a recovery code, and entered on
+the second device. It is never sent anywhere and cannot be recovered — the
+screen says so rather than burying it. A fresh random IV per write matters more
+than usual here: the same library is re-encrypted on every change, so a fixed
+IV would leak which parts changed between two versions sitting in the cloud.
+
+GCM authenticates, so a file written with a different key fails cleanly rather
+than decrypting to garbage. That is what lets a shared folder hold an unrelated
+setup's files without either one importing the other's rubbish.
+
+---
+
+## Failure handling
+
+Everything degrades quietly, because a folder behind a cloud client is
+routinely half-written, unmounted or revoked:
+
+- A file that will not decrypt is skipped, not an error.
+- A file that will not parse is skipped. One bad file must not fail the sync.
+- A file from a newer format version is skipped rather than partially imported.
+- A revoked folder grant becomes a state the UI describes and offers to fix,
+  not an exception.
+- Settings arriving in a payload are filtered against an allow-list. The file
+  comes out of a directory the user controls, so it is treated as untrusted
+  input rather than as our own data coming home.
+
+---
+
+## Layout
+
+| Path | |
+|---|---|
+| `lib/sync/sync_merge.dart` | Records, tombstones, merge rules. No Flutter import; the most-tested file here. |
+| `lib/sync/sync_payload.dart` | The document format and the N-way fold. |
+| `lib/sync/sync_service.dart` | Read, merge, apply, write. |
+| `lib/sync/sync_channel.dart` | Dart side of the bridge. |
+| `android/.../sync/SyncBridge.kt` | SAF folder access and AES-GCM. |
+| `lib/screens/sync_screen.dart` | Setup, recovery code, status. |
+
+---
+
+## Status
+
+Built and unit-tested; **not yet verified on two real devices**. The merge
+rules have 13 tests covering the cases a two-phone setup actually produces, but
+the round trip through a real synced folder — two phones, one folder, edits on
+both — has not been run.

--- a/lib/api/local_media_channel.dart
+++ b/lib/api/local_media_channel.dart
@@ -116,20 +116,127 @@ String folderLocation(String path) {
   return parent.isEmpty ? 'Internal storage' : parent;
 }
 
-/// Whether [path] is one of [roots] or sits inside one.
+/// Which folders the on-device library takes music from.
 ///
-/// An empty [roots] means everything: no folders chosen is the default, and it
-/// has to mean the whole device rather than nothing at all, or the library
-/// would be empty until the setting was found.
+/// One rule beats two lists. An include-only list cannot express "everything
+/// except the ringtones", and — worse — it silently drops music added later,
+/// because a folder that did not exist when the list was made is not on it. An
+/// exclude-only list cannot express "just this one folder" without naming
+/// every sibling. Both failures are silent, which is the worst kind.
 ///
-/// The separator in the prefix test is load-bearing: without it `/Music` would
-/// swallow `/MusicVideos`, hiding music the user never excluded.
-bool isUnderAnyRoot(String path, Set<String> roots) {
-  if (roots.isEmpty) return true;
-  for (final root in roots) {
-    if (path == root || path.startsWith('$root/')) return true;
+/// So: a default for the device, plus per-folder overrides, resolved by taking
+/// the nearest rule up the path. A folder with no rule of its own follows its
+/// parent, and a folder whose parents have no rule follows the default — which
+/// is how a folder created tomorrow gets the behaviour its parent has today.
+class FolderRules {
+  const FolderRules({
+    this.defaultIncluded = true,
+    this.overrides = const <String, bool>{},
+  });
+
+  /// What a folder does when nothing above it says otherwise. True — take
+  /// everything — is the default so a fresh install finds all the music on the
+  /// phone without this screen ever being opened.
+  final bool defaultIncluded;
+
+  /// Absolute folder path to whether it, and everything under it, is taken.
+  /// Only folders that differ from what they would inherit appear here, so the
+  /// map stays the shortest description of the choice.
+  final Map<String, bool> overrides;
+
+  bool get isDefault => defaultIncluded && overrides.isEmpty;
+
+  /// Whether music in [folder] belongs in the library.
+  bool allows(String folder) => _resolve(folder);
+
+  /// What [folder] would be with no rule of its own — what a tick on it would
+  /// have to disagree with to be worth storing.
+  bool inherited(String folder) => _resolve(_parent(folder));
+
+  bool _resolve(String? from) {
+    var p = from;
+    while (p != null && p.isNotEmpty) {
+      final rule = overrides[p];
+      if (rule != null) return rule;
+      p = _parent(p);
+    }
+    return defaultIncluded;
   }
-  return false;
+
+  /// The nearest enclosing directory, or null at the top of a volume.
+  ///
+  /// Stopping at index 0 rather than returning '/' keeps the walk off a root
+  /// that no rule can name: every path here is absolute, so a '/' rule would
+  /// be a second way to say [defaultIncluded].
+  static String? _parent(String path) {
+    final i = path.lastIndexOf('/');
+    return i <= 0 ? null : path.substring(0, i);
+  }
+
+  /// Set [folder] and everything under it.
+  ///
+  /// Only this folder's own rule changes. A rule that agrees with what the
+  /// folder already inherits is dropped rather than stored, because setting
+  /// something to what it already was is not a decision worth recording.
+  FolderRules set(String folder, {required bool included}) {
+    final next = {...overrides};
+    if (included == inherited(folder)) {
+      next.remove(folder);
+    } else {
+      next[folder] = included;
+    }
+    return FolderRules(defaultIncluded: defaultIncluded, overrides: next);
+  }
+
+  /// Change the device-wide default — what folders with nothing above them
+  /// follow, including folders that do not exist yet.
+  FolderRules withDefault({required bool included}) =>
+      FolderRules(defaultIncluded: included, overrides: overrides);
+
+  // Rules are never tidied away for being redundant, and that is deliberate.
+  //
+  // A rule can be redundant now and load-bearing after one tap somewhere else:
+  // "leave this album out" says nothing while the whole device is off, and is
+  // the only thing keeping it out the moment its folder is turned back on.
+  // Dropping it in between silently resurrects music the user removed, and the
+  // resurrection happens far from the tap that caused it.
+  //
+  // The cost is a rule set that can hold entries changing nothing today. They
+  // cannot change an answer — resolution takes the nearest rule, and a
+  // redundant one gives what would have been inherited anyway — and there are
+  // only ever as many as the user has touched folders.
+
+  bool sameAs(FolderRules other) {
+    if (defaultIncluded != other.defaultIncluded) return false;
+    if (overrides.length != other.overrides.length) return false;
+    for (final e in overrides.entries) {
+      if (other.overrides[e.key] != e.value) return false;
+    }
+    return true;
+  }
+
+  /// Stored as one list of strings so a Hive dump stays readable and a
+  /// half-written value degrades to "take everything" rather than to nothing.
+  /// Paths are absolute, so they cannot collide with the default marker.
+  List<String> encode() => [
+    defaultIncluded ? 'default+' : 'default-',
+    for (final e in overrides.entries) '${e.value ? '+' : '-'}${e.key}',
+  ];
+
+  static FolderRules decode(Iterable<String> raw) {
+    var byDefault = true;
+    final overrides = <String, bool>{};
+    for (final line in raw) {
+      if (line == 'default+') {
+        byDefault = true;
+      } else if (line == 'default-') {
+        byDefault = false;
+      } else if (line.length > 2 && (line[0] == '+' || line[0] == '-')) {
+        overrides[line.substring(1)] = line[0] == '+';
+      }
+    }
+    return FolderRules(defaultIncluded: byDefault, overrides: overrides);
+  }
 }
 
 /// The directory part of a file path, or empty when there isn't one.
@@ -160,23 +267,19 @@ class LocalMediaChannel {
   /// permission, an unreadable volume, a platform that isn't Android. The
   /// caller distinguishes "no music" from "not allowed" by checking the
   /// permission itself, not by catching from here.
-  /// [includedFolders] are absolute directory roots to take music from. Empty
-  /// — the default — means the whole device, so a fresh install finds
-  /// everything without being configured first.
-  ///
-  /// A root covers its subfolders. One album-per-folder library is a hundred
-  /// directories under one parent; asking someone to tick each of them would
-  /// make the setting useless for exactly the libraries that need it.
+  /// [rules] decide which folders count — see [FolderRules]. The default takes
+  /// the whole device, so a fresh install finds everything without being
+  /// configured first.
   ///
   /// Filtering happens here rather than in the query because the folder list
   /// the user picks from has to show every folder on the device, including the
   /// ones currently left out, and a filtered query could not report those.
-  Future<LocalScan> scan({Set<String> includedFolders = const {}}) async {
+  Future<LocalScan> scan({FolderRules rules = const FolderRules()}) async {
     if (!_supported) return const LocalScan.empty();
     try {
       final raw = await _channel.invokeListMethod<Object?>('scan');
       if (raw == null) return const LocalScan.empty();
-      return _group(raw, includedFolders);
+      return _group(raw, rules);
     } on PlatformException catch (e) {
       debugPrint('[local] scan failed: ${e.message}');
       return const LocalScan.empty();
@@ -191,7 +294,7 @@ class LocalMediaChannel {
   /// Insertion order is preserved throughout: the query returns newest-first,
   /// so albums come out most-recently-added first, which is what someone
   /// looking for music they just copied over expects.
-  static LocalScan _group(List<Object?> rows, Set<String> included) {
+  static LocalScan _group(List<Object?> rows, FolderRules rules) {
     final songs = <FeedItem>[];
     final albums = <String, List<FeedItem>>{};
     final albumNames = <String, String>{};
@@ -212,8 +315,8 @@ class LocalMediaChannel {
         folderCounts[folder] = (folderCounts[folder] ?? 0) + 1;
       }
       // Left out of the library, but still counted above so the folder can be
-      // found and added.
-      if (!isUnderAnyRoot(folder, included)) continue;
+      // found and put back.
+      if (!rules.allows(folder)) continue;
 
       songs.add(song);
 
@@ -259,7 +362,8 @@ class LocalMediaChannel {
       '[local] scanned ${songs.length} tracks, '
       '${albums.length} albums, ${artists.length} artists, '
       '${folderCounts.length} folders '
-      '(${included.isEmpty ? 'all' : '${included.length} chosen'})',
+      '(${rules.isDefault ? 'all' : '${rules.overrides.length} rule(s), '
+                'default ${rules.defaultIncluded ? 'in' : 'out'}'})',
     );
     return LocalScan(
       songs: songs,

--- a/lib/api/local_media_channel.dart
+++ b/lib/api/local_media_channel.dart
@@ -42,21 +42,100 @@ class LocalCollection {
   }
 }
 
+/// One folder on the device that holds music, and how much.
+///
+/// Derived from the file paths rather than asked for separately: MediaStore
+/// has no folder table, and the path is already on every row.
+class LocalFolder {
+  const LocalFolder({
+    required this.path,
+    required this.name,
+    required this.trackCount,
+  });
+
+  /// Absolute directory path. This is the identity used by the ignore list,
+  /// so it is stored verbatim and never normalised or prettified.
+  final String path;
+
+  /// Last path segment, for display. Folders are usually recognisable by
+  /// their own name; the full path is long and mostly noise.
+  final String name;
+
+  final int trackCount;
+}
+
 /// Everything one scan produced.
 class LocalScan {
   const LocalScan({
     required this.songs,
     required this.albums,
     required this.artists,
+    this.folders = const [],
   });
   const LocalScan.empty()
     : songs = const [],
       albums = const [],
-      artists = const [];
+      artists = const [],
+      folders = const [];
 
   final List<FeedItem> songs;
   final List<LocalCollection> albums;
   final List<LocalCollection> artists;
+
+  /// Every folder the scan saw, **including ones left out**, largest first.
+  ///
+  /// The excluded ones have to be here or there is no way back: a folder
+  /// missing from the library would vanish from the list that lets you add
+  /// it.
+  final List<LocalFolder> folders;
+}
+
+/// Where a folder sits, written the way a person would read it.
+///
+/// The full path is useless as a subtitle: on a real device every music folder
+/// starts `/storage/emulated/0/Download/...`, so a row that elides the tail
+/// shows the same string for every folder and disambiguates nothing. The
+/// distinguishing part is at the end, and the last segment is already the
+/// row's title — so this drops the storage prefix and the name, leaving the
+/// parent chain that actually tells two same-named folders apart.
+String folderLocation(String path) {
+  var p = path;
+  for (final prefix in const [
+    '/storage/emulated/0',
+    '/sdcard',
+    '/mnt/sdcard',
+  ]) {
+    if (p == prefix) return 'Internal storage';
+    if (p.startsWith('$prefix/')) {
+      p = p.substring(prefix.length);
+      break;
+    }
+  }
+  final i = p.lastIndexOf('/');
+  final parent = i <= 0 ? '' : p.substring(1, i);
+  return parent.isEmpty ? 'Internal storage' : parent;
+}
+
+/// Whether [path] is one of [roots] or sits inside one.
+///
+/// An empty [roots] means everything: no folders chosen is the default, and it
+/// has to mean the whole device rather than nothing at all, or the library
+/// would be empty until the setting was found.
+///
+/// The separator in the prefix test is load-bearing: without it `/Music` would
+/// swallow `/MusicVideos`, hiding music the user never excluded.
+bool isUnderAnyRoot(String path, Set<String> roots) {
+  if (roots.isEmpty) return true;
+  for (final root in roots) {
+    if (path == root || path.startsWith('$root/')) return true;
+  }
+  return false;
+}
+
+/// The directory part of a file path, or empty when there isn't one.
+String folderOf(String path) {
+  final i = path.lastIndexOf('/');
+  return i <= 0 ? '' : path.substring(0, i);
 }
 
 /// The `source` marker carried by every on-device track.
@@ -81,12 +160,23 @@ class LocalMediaChannel {
   /// permission, an unreadable volume, a platform that isn't Android. The
   /// caller distinguishes "no music" from "not allowed" by checking the
   /// permission itself, not by catching from here.
-  Future<LocalScan> scan() async {
+  /// [includedFolders] are absolute directory roots to take music from. Empty
+  /// — the default — means the whole device, so a fresh install finds
+  /// everything without being configured first.
+  ///
+  /// A root covers its subfolders. One album-per-folder library is a hundred
+  /// directories under one parent; asking someone to tick each of them would
+  /// make the setting useless for exactly the libraries that need it.
+  ///
+  /// Filtering happens here rather than in the query because the folder list
+  /// the user picks from has to show every folder on the device, including the
+  /// ones currently left out, and a filtered query could not report those.
+  Future<LocalScan> scan({Set<String> includedFolders = const {}}) async {
     if (!_supported) return const LocalScan.empty();
     try {
       final raw = await _channel.invokeListMethod<Object?>('scan');
       if (raw == null) return const LocalScan.empty();
-      return _group(raw);
+      return _group(raw, includedFolders);
     } on PlatformException catch (e) {
       debugPrint('[local] scan failed: ${e.message}');
       return const LocalScan.empty();
@@ -101,19 +191,30 @@ class LocalMediaChannel {
   /// Insertion order is preserved throughout: the query returns newest-first,
   /// so albums come out most-recently-added first, which is what someone
   /// looking for music they just copied over expects.
-  static LocalScan _group(List<Object?> rows) {
+  static LocalScan _group(List<Object?> rows, Set<String> included) {
     final songs = <FeedItem>[];
     final albums = <String, List<FeedItem>>{};
     final albumNames = <String, String>{};
     final albumArtistSets = <String, Set<String>>{};
     final artists = <String, List<FeedItem>>{};
     final artistNames = <String, String>{};
+    // Counted over every row, included or not — see LocalScan.folders.
+    final folderCounts = <String, int>{};
 
     for (final row in rows) {
       if (row is! Map) continue;
       final r = row.cast<Object?, Object?>();
       final song = _toFeedItem(r);
       if (song == null) continue;
+
+      final folder = folderOf(song.url ?? '');
+      if (folder.isNotEmpty) {
+        folderCounts[folder] = (folderCounts[folder] ?? 0) + 1;
+      }
+      // Left out of the library, but still counted above so the folder can be
+      // found and added.
+      if (!isUnderAnyRoot(folder, included)) continue;
+
       songs.add(song);
 
       final artist = _clean((r['artist'] ?? '').toString());
@@ -156,7 +257,9 @@ class LocalMediaChannel {
 
     debugPrint(
       '[local] scanned ${songs.length} tracks, '
-      '${albums.length} albums, ${artists.length} artists',
+      '${albums.length} albums, ${artists.length} artists, '
+      '${folderCounts.length} folders '
+      '(${included.isEmpty ? 'all' : '${included.length} chosen'})',
     );
     return LocalScan(
       songs: songs,
@@ -178,7 +281,22 @@ class LocalMediaChannel {
             songs: e.value,
           ),
       ],
+      folders: _foldersFrom(folderCounts),
     );
+  }
+
+  /// Folders sorted by size, largest first: the one worth excluding is
+  /// usually the one with three hundred notification tones in it.
+  static List<LocalFolder> _foldersFrom(Map<String, int> counts) {
+    final out = [
+      for (final e in counts.entries)
+        LocalFolder(
+          path: e.key,
+          name: e.key.substring(e.key.lastIndexOf('/') + 1),
+          trackCount: e.value,
+        ),
+    ]..sort((a, b) => b.trackCount.compareTo(a.trackCount));
+    return out;
   }
 
   /// The artist line for an album: the one artist if it has a single one,

--- a/lib/audio/library_store.dart
+++ b/lib/audio/library_store.dart
@@ -17,6 +17,7 @@ import 'package:hive_ce_flutter/hive_flutter.dart';
 
 import '../api/dto.dart';
 import '../data/user_playlist.dart';
+import '../sync/sync_merge.dart';
 
 class LibraryStore {
   LibraryStore();
@@ -39,7 +40,24 @@ class LibraryStore {
   // resume-where-you-left-off works across cold starts. Capped at
   // [_maxEpisodeProgress] entries (LRU by updatedAt).
   static const _kEpisodeProgress = 'episode_progress';
+
+  /// Timestamps and tombstones for everything syncable, keyed
+  /// `collection:id`. See `sync/sync_merge.dart` for why it sits beside the
+  /// collections rather than inside them: the stored shapes above are exactly
+  /// what they always were, so nothing here needs migrating and a library
+  /// written before sync existed still reads.
+  static const _kSyncMeta = 'sync_meta';
   static const _maxEpisodeProgress = 200;
+
+  /// Collection names for sync metadata. Deliberately short and stable: they
+  /// are written into every device's sync file, so renaming one silently
+  /// orphans the other device's records for that collection.
+  static const cLiked = 'liked';
+  static const cAlbum = 'album';
+  static const cPlaylist = 'playlist';
+  static const cArtist = 'artist';
+  static const cUserPlaylist = 'uplaylist';
+  static const cPodcast = 'podcast';
 
   /// Max items kept in the played-history list. Older entries get evicted
   /// LRU-style. 50 is enough for "Recently Played" sections without growing
@@ -113,6 +131,103 @@ class LibraryStore {
     return box;
   }
 
+  // ── Bulk replace, for applying a merge ─────────────────────────────────
+  //
+  // These write a whole collection at once and deliberately do NOT touch sync
+  // metadata: a merge result is not a user action, and stamping it with "now"
+  // would make every sync look like a fresh edit on this device and win every
+  // future tie. The service writes the merged metadata itself, once.
+
+  Future<void> replaceLiked(List<FeedItem> items) =>
+      _replace(_kLikedSongs, items);
+
+  Future<void> replaceSaved(String kind, List<FeedItem> items) =>
+      _replace(_keyForKind(kind), items);
+
+  Future<void> replaceSubscribedPodcasts(List<FeedItem> items) =>
+      _replace(_kSubscribedPodcasts, items);
+
+  Future<void> _replace(String key, List<FeedItem> items) async {
+    try {
+      final box = await _box();
+      await box.put(key, _encodeList(items));
+      await box.flush();
+    } catch (e) {
+      debugPrint('[library-store] replace $key failed: $e');
+    }
+  }
+
+  Future<void> replaceUserPlaylists(List<UserPlaylist> playlists) async {
+    try {
+      final box = await _box();
+      await box.put(_kUserPlaylists, _encodePlaylists(playlists));
+      await box.flush();
+    } catch (e) {
+      debugPrint('[library-store] replace user playlists failed: $e');
+    }
+  }
+
+  Future<void> replaceEpisodeProgress(Map<String, int> progress) async {
+    try {
+      final box = await _box();
+      // Same `{pos, t}` shape and LRU cap the incremental writer uses, so a
+      // merge cannot grow the box past what normal use would, and the reader
+      // does not need to know a merge happened.
+      final now = DateTime.now().millisecondsSinceEpoch;
+      final capped = progress.entries.toList()
+        ..sort((a, b) => b.value.compareTo(a.value));
+      await box.put(_kEpisodeProgress, {
+        for (final e in capped.take(_maxEpisodeProgress))
+          e.key: {'pos': e.value, 't': now},
+      });
+      await box.flush();
+    } catch (e) {
+      debugPrint('[library-store] replace episode progress failed: $e');
+    }
+  }
+
+  // ── Sync metadata ──────────────────────────────────────────────────────
+
+  Future<SyncMeta> loadSyncMeta() async {
+    try {
+      final box = await _box();
+      return SyncMeta.fromJson(box.get(_kSyncMeta));
+    } catch (e) {
+      debugPrint('[library-store] sync meta read failed: $e');
+      return SyncMeta();
+    }
+  }
+
+  Future<void> saveSyncMeta(SyncMeta meta) async {
+    try {
+      final box = await _box();
+      await box.put(_kSyncMeta, meta.toJson());
+      await box.flush();
+    } catch (e) {
+      debugPrint('[library-store] sync meta write failed: $e');
+    }
+  }
+
+  /// Record that [id] in [collection] was just added or removed.
+  ///
+  /// Called from every mutation below. A mutation that forgets to call this
+  /// still works locally and is simply invisible to sync, which is the quiet
+  /// failure to watch for when adding a new collection.
+  Future<void> _touch(
+    String collection,
+    String id, {
+    required bool deleted,
+  }) async {
+    if (id.isEmpty) return;
+    final meta = await loadSyncMeta();
+    if (deleted) {
+      meta.markDeleted(collection, id);
+    } else {
+      meta.markAdded(collection, id);
+    }
+    await saveSyncMeta(meta);
+  }
+
   List<FeedItem> _decodeList(Object? raw) {
     // CRITICAL: must return a *growable, modifiable* list because every
     // mutation path (setLiked / pushHistory / setSaved) does
@@ -175,6 +290,7 @@ class LibraryStore {
     current.removeWhere((s) => s.id == song.id);
     if (liked) current.insert(0, song);
     await box.put(_kLikedSongs, _encodeList(current));
+    await _touch(cLiked, song.id, deleted: !liked);
     // Force fsync — Hive buffers writes by default; without flush, a
     // crash or fast subsequent `adb install` can drop the write.
     await box.flush();
@@ -222,6 +338,13 @@ class LibraryStore {
   // Same shape as liked_songs but separate keys so the UI can show
   // them in their own buckets (and the user can have a Maroon 5 album
   // saved without that artist being followed, etc.).
+
+  /// Map a saved-item kind onto its sync collection name.
+  static String _collectionForKind(String kind) => switch (kind) {
+    'album' => cAlbum,
+    'artist' => cArtist,
+    _ => cPlaylist,
+  };
 
   String _keyForKind(String kind) {
     switch (kind) {
@@ -275,6 +398,7 @@ class LibraryStore {
     current.removeWhere((s) => s.id == item.id);
     if (saved) current.insert(0, item);
     await box.put(key, _encodeList(current));
+    await _touch(_collectionForKind(item.type), item.id, deleted: !saved);
     await box.flush();
     debugPrint(
       '[library-store] saved=${saved ? 'on' : 'off'} '
@@ -317,6 +441,7 @@ class LibraryStore {
     current.removeWhere((x) => x.id == p.id);
     current.insert(0, p);
     await box.put(_kUserPlaylists, _encodePlaylists(current));
+    await _touch(cUserPlaylist, p.id, deleted: false);
     await box.flush();
     debugPrint(
       '[library-store] upsert user-playlist "${p.name}" '
@@ -330,6 +455,7 @@ class LibraryStore {
     final current = _decodePlaylists(box.get(_kUserPlaylists));
     current.removeWhere((p) => p.id == id);
     await box.put(_kUserPlaylists, _encodePlaylists(current));
+    await _touch(cUserPlaylist, id, deleted: true);
     await box.flush();
     debugPrint(
       '[library-store] deleted user-playlist $id '
@@ -378,6 +504,7 @@ class LibraryStore {
     current.removeWhere((s) => s.id == show.id);
     if (subscribed) current.insert(0, show);
     await box.put(_kSubscribedPodcasts, _encodeList(current));
+    await _touch(cPodcast, show.id, deleted: !subscribed);
     await box.flush();
     debugPrint(
       '[library-store] subscribed=${subscribed ? 'on' : 'off'} '

--- a/lib/audio/local_library.dart
+++ b/lib/audio/local_library.dart
@@ -15,6 +15,7 @@ import 'package:permission_handler/permission_handler.dart';
 
 import '../api/dto.dart';
 import '../api/local_media_channel.dart';
+import 'settings_store.dart';
 
 /// Why the local library is empty, when it is.
 enum LocalLibraryStatus {
@@ -36,10 +37,40 @@ enum LocalLibraryStatus {
 }
 
 class LocalLibrary extends ChangeNotifier {
-  LocalLibrary({LocalMediaChannel? channel})
-    : _channel = channel ?? LocalMediaChannel.instance;
+  LocalLibrary({LocalMediaChannel? channel, SettingsStore? settings})
+    : _channel = channel ?? LocalMediaChannel.instance,
+      _settings = settings ?? SettingsStore();
 
   final LocalMediaChannel _channel;
+  final SettingsStore _settings;
+
+  Set<String> _included = const {};
+
+  /// Folder roots the library takes music from. Empty means the whole device.
+  Set<String> get includedFolders => _included;
+
+  /// Every folder holding music, including ones left out, largest first.
+  List<LocalFolder> get folders => _scan.folders;
+
+  /// Replace the set of folder roots to scan, then rescan.
+  ///
+  /// Takes the whole set rather than one folder at a time because the screen
+  /// applies a selection: choosing six folders one call at a time would mean
+  /// six rescans, five of them showing a library the user never asked to see.
+  ///
+  /// A rescan rather than filtering in memory: the album and artist groupings
+  /// are built from the raw MediaStore rows, where album and artist are still
+  /// separate columns, and rebuilding them from already-mapped items would
+  /// mean parsing a display string back apart. The scan is cheap on a warm
+  /// album-art cache.
+  Future<void> setIncludedFolders(Set<String> paths) async {
+    final next = Set<String>.unmodifiable(paths);
+    if (next.length == _included.length && next.containsAll(_included)) return;
+    _included = next;
+    await _settings.saveIncludedFolders(next);
+    notifyListeners();
+    await load(force: true);
+  }
 
   LocalLibraryStatus _status = LocalLibraryStatus.idle;
   LocalLibraryStatus get status => _status;
@@ -84,7 +115,8 @@ class LocalLibrary extends ChangeNotifier {
   Future<void> _scanNow() async {
     if (_status == LocalLibraryStatus.scanning) return;
     _set(LocalLibraryStatus.scanning);
-    _scan = await _channel.scan();
+    _included = await _settings.loadIncludedFolders();
+    _scan = await _channel.scan(includedFolders: _included);
     _set(LocalLibraryStatus.ready);
   }
 

--- a/lib/audio/local_library.dart
+++ b/lib/audio/local_library.dart
@@ -44,30 +44,29 @@ class LocalLibrary extends ChangeNotifier {
   final LocalMediaChannel _channel;
   final SettingsStore _settings;
 
-  Set<String> _included = const {};
+  FolderRules _rules = const FolderRules();
 
-  /// Folder roots the library takes music from. Empty means the whole device.
-  Set<String> get includedFolders => _included;
+  /// Which folders the library takes music from.
+  FolderRules get folderRules => _rules;
 
   /// Every folder holding music, including ones left out, largest first.
   List<LocalFolder> get folders => _scan.folders;
 
-  /// Replace the set of folder roots to scan, then rescan.
+  /// Replace the folder rules, then rescan.
   ///
-  /// Takes the whole set rather than one folder at a time because the screen
-  /// applies a selection: choosing six folders one call at a time would mean
-  /// six rescans, five of them showing a library the user never asked to see.
+  /// Takes the whole rule set rather than one folder at a time because the
+  /// screen applies a selection: changing six folders one call at a time would
+  /// mean six rescans, five of them showing a library nobody asked to see.
   ///
   /// A rescan rather than filtering in memory: the album and artist groupings
   /// are built from the raw MediaStore rows, where album and artist are still
   /// separate columns, and rebuilding them from already-mapped items would
   /// mean parsing a display string back apart. The scan is cheap on a warm
   /// album-art cache.
-  Future<void> setIncludedFolders(Set<String> paths) async {
-    final next = Set<String>.unmodifiable(paths);
-    if (next.length == _included.length && next.containsAll(_included)) return;
-    _included = next;
-    await _settings.saveIncludedFolders(next);
+  Future<void> setFolderRules(FolderRules rules) async {
+    if (rules.sameAs(_rules)) return;
+    _rules = rules;
+    await _settings.saveFolderRules(rules);
     notifyListeners();
     await load(force: true);
   }
@@ -115,8 +114,8 @@ class LocalLibrary extends ChangeNotifier {
   Future<void> _scanNow() async {
     if (_status == LocalLibraryStatus.scanning) return;
     _set(LocalLibraryStatus.scanning);
-    _included = await _settings.loadIncludedFolders();
-    _scan = await _channel.scan(includedFolders: _included);
+    _rules = await _settings.loadFolderRules();
+    _scan = await _channel.scan(rules: _rules);
     _set(LocalLibraryStatus.ready);
   }
 

--- a/lib/audio/settings_store.dart
+++ b/lib/audio/settings_store.dart
@@ -6,6 +6,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:hive_ce_flutter/hive_flutter.dart';
 
+import '../api/local_media_channel.dart';
+
 class SavedEqState {
   const SavedEqState({required this.bands, this.presetId});
   final List<double> bands;
@@ -98,13 +100,13 @@ class SettingsStore {
   // shown to the user once as a recovery code, and the device id names this
   // device's file in the folder. All three live here rather than in the
   // library box because they configure sync, they are not synced by it.
-  /// Absolute folder roots the on-device library takes music from. Empty
-  /// means the whole device.
+  /// Which folders the on-device library takes music from, encoded by
+  /// [FolderRules]. Absent means the whole device.
   ///
   /// Not synced between devices: the same music sits under different paths on
   /// different phones, so one device's folder choice is meaningless on another
   /// and would silently hide the wrong music.
-  static const _kIncludedFolders = 'local.included_folders';
+  static const _kFolderRules = 'local.folder_rules';
 
   static const _kSyncTree = 'sync.tree_uri';
   static const _kSyncKey = 'sync.key';
@@ -380,25 +382,25 @@ extension SyncSettings on SettingsStore {
     'playback.yt_language',
   ];
 
-  Future<Set<String>> loadIncludedFolders() async {
+  Future<FolderRules> loadFolderRules() async {
     try {
       final box = await _box();
-      final raw = box.get(SettingsStore._kIncludedFolders);
-      if (raw is! List) return <String>{};
-      return raw.whereType<String>().toSet();
+      final raw = box.get(SettingsStore._kFolderRules);
+      if (raw is! List) return const FolderRules();
+      return FolderRules.decode(raw.whereType<String>());
     } catch (e) {
-      debugPrint('[settings-store] loadIncludedFolders failed: $e');
-      return <String>{};
+      debugPrint('[settings-store] loadFolderRules failed: $e');
+      return const FolderRules();
     }
   }
 
-  Future<void> saveIncludedFolders(Set<String> folders) async {
+  Future<void> saveFolderRules(FolderRules rules) async {
     try {
       final box = await _box();
-      await box.put(SettingsStore._kIncludedFolders, folders.toList());
+      await box.put(SettingsStore._kFolderRules, rules.encode());
       await box.flush();
     } catch (e) {
-      debugPrint('[settings-store] saveIncludedFolders failed: $e');
+      debugPrint('[settings-store] saveFolderRules failed: $e');
     }
   }
 

--- a/lib/audio/settings_store.dart
+++ b/lib/audio/settings_store.dart
@@ -98,6 +98,14 @@ class SettingsStore {
   // shown to the user once as a recovery code, and the device id names this
   // device's file in the folder. All three live here rather than in the
   // library box because they configure sync, they are not synced by it.
+  /// Absolute folder roots the on-device library takes music from. Empty
+  /// means the whole device.
+  ///
+  /// Not synced between devices: the same music sits under different paths on
+  /// different phones, so one device's folder choice is meaningless on another
+  /// and would silently hide the wrong music.
+  static const _kIncludedFolders = 'local.included_folders';
+
   static const _kSyncTree = 'sync.tree_uri';
   static const _kSyncKey = 'sync.key';
   static const _kSyncDevice = 'sync.device_id';
@@ -371,6 +379,28 @@ extension SyncSettings on SettingsStore {
     'playback.yt_country',
     'playback.yt_language',
   ];
+
+  Future<Set<String>> loadIncludedFolders() async {
+    try {
+      final box = await _box();
+      final raw = box.get(SettingsStore._kIncludedFolders);
+      if (raw is! List) return <String>{};
+      return raw.whereType<String>().toSet();
+    } catch (e) {
+      debugPrint('[settings-store] loadIncludedFolders failed: $e');
+      return <String>{};
+    }
+  }
+
+  Future<void> saveIncludedFolders(Set<String> folders) async {
+    try {
+      final box = await _box();
+      await box.put(SettingsStore._kIncludedFolders, folders.toList());
+      await box.flush();
+    } catch (e) {
+      debugPrint('[settings-store] saveIncludedFolders failed: $e');
+    }
+  }
 
   Future<SavedSync> loadSync() async {
     try {

--- a/lib/audio/settings_store.dart
+++ b/lib/audio/settings_store.dart
@@ -93,6 +93,17 @@ class SettingsStore {
   // Search
   static const _kSearchRecents = 'search.recents';
 
+  // ── Library sync ─────────────────────────────────────────────────────
+  // The tree URI is a persisted SAF grant, the key is the base64 AES key
+  // shown to the user once as a recovery code, and the device id names this
+  // device's file in the folder. All three live here rather than in the
+  // library box because they configure sync, they are not synced by it.
+  static const _kSyncTree = 'sync.tree_uri';
+  static const _kSyncKey = 'sync.key';
+  static const _kSyncDevice = 'sync.device_id';
+  static const _kSyncLastAt = 'sync.last_at';
+  static const _kSyncSettingsAt = 'sync.settings_at';
+
   /// Cap on persisted search recents — older queries fall off the list
   /// once we cross this. 10 is plenty for the chips UI without forcing
   /// the user to scroll.
@@ -102,7 +113,6 @@ class SettingsStore {
   // user dismissed. When the published version equals this, we stay quiet;
   // when it surpasses it (next release), the banner returns.
   static const _kDismissedUpdate = 'updates.dismissed_version';
-
 
   /// Cached in-flight open so concurrent loaders share one openBox call
   /// — same race-avoidance idiom as library_store.
@@ -322,6 +332,141 @@ class SettingsStore {
   }
 
   // ── Privacy ─────────────────────────────────────────────────────────────
+}
 
+/// Sync configuration as stored.
+class SavedSync {
+  const SavedSync({this.treeUri, this.key, this.deviceId, this.lastSyncAt});
+  final String? treeUri;
+  final String? key;
+  final String? deviceId;
+  final int? lastSyncAt;
+}
 
+/// The settings that travel between devices, with the time they last changed.
+class SyncableSettings {
+  const SyncableSettings({required this.values, required this.updatedAt});
+  final Map<String, dynamic> values;
+  final int updatedAt;
+}
+
+extension SyncSettings on SettingsStore {
+  /// Keys that sync.
+  ///
+  /// Appearance and playback preferences travel; anything describing *this*
+  /// device or its history does not. Search recents are deliberately excluded:
+  /// they are a local convenience and carry what you typed, which is the last
+  /// thing that should be copied into a shared folder.
+  static const syncableKeys = [
+    'appearance.accent',
+    'appearance.density',
+    'appearance.tint_from_art',
+    'appearance.tint_intensity',
+    'appearance.theme',
+    'playback.stream_quality',
+    'playback.repeat_mode',
+    'playback.languages',
+    'playback.endless_autoplay',
+    'playback.sponsorblock',
+    'playback.yt_country',
+    'playback.yt_language',
+  ];
+
+  Future<SavedSync> loadSync() async {
+    try {
+      final box = await _box();
+      String? nonEmpty(Object? v) {
+        final s = v?.toString();
+        return (s == null || s.isEmpty) ? null : s;
+      }
+
+      return SavedSync(
+        treeUri: nonEmpty(box.get(SettingsStore._kSyncTree)),
+        key: nonEmpty(box.get(SettingsStore._kSyncKey)),
+        deviceId: nonEmpty(box.get(SettingsStore._kSyncDevice)),
+        lastSyncAt: (box.get(SettingsStore._kSyncLastAt) as num?)?.toInt(),
+      );
+    } catch (e) {
+      debugPrint('[settings-store] loadSync failed: $e');
+      return const SavedSync();
+    }
+  }
+
+  Future<void> saveSync({
+    required String treeUri,
+    required String key,
+    required String deviceId,
+    int? lastSyncAt,
+  }) async {
+    try {
+      final box = await _box();
+      await box.putAll({
+        SettingsStore._kSyncTree: treeUri,
+        SettingsStore._kSyncKey: key,
+        SettingsStore._kSyncDevice: deviceId,
+        SettingsStore._kSyncLastAt: ?lastSyncAt,
+      });
+      await box.flush();
+    } catch (e) {
+      debugPrint('[settings-store] saveSync failed: $e');
+    }
+  }
+
+  Future<SyncableSettings> loadSyncableSettings() async {
+    try {
+      final box = await _box();
+      return SyncableSettings(
+        values: {
+          for (final k in syncableKeys)
+            if (box.get(k) != null) k: box.get(k),
+        },
+        updatedAt:
+            (box.get(SettingsStore._kSyncSettingsAt) as num?)?.toInt() ?? 0,
+      );
+    } catch (e) {
+      debugPrint('[settings-store] loadSyncableSettings failed: $e');
+      return const SyncableSettings(values: {}, updatedAt: 0);
+    }
+  }
+
+  /// Apply another device's settings, whole-set.
+  ///
+  /// Only keys in [syncableKeys] are written, however the incoming file is
+  /// shaped: the payload comes out of a folder the user controls, so it is
+  /// treated as untrusted input rather than as our own data coming home.
+  Future<void> applySyncableSettings(
+    Map<String, dynamic> values,
+    int updatedAt,
+  ) async {
+    try {
+      final box = await _box();
+      final allowed = {
+        for (final e in values.entries)
+          if (syncableKeys.contains(e.key)) e.key: e.value,
+      };
+      if (allowed.isEmpty) return;
+      await box.putAll({...allowed, SettingsStore._kSyncSettingsAt: updatedAt});
+      await box.flush();
+      debugPrint(
+        '[settings-store] applied ${allowed.length} synced setting(s)',
+      );
+    } catch (e) {
+      debugPrint('[settings-store] applySyncableSettings failed: $e');
+    }
+  }
+
+  /// Stamp the moment local settings last changed, so the newest set wins a
+  /// merge. Called from the settings mutators.
+  Future<void> touchSettingsChanged() async {
+    try {
+      final box = await _box();
+      await box.put(
+        SettingsStore._kSyncSettingsAt,
+        DateTime.now().millisecondsSinceEpoch,
+      );
+      await box.flush();
+    } catch (_) {
+      // A missed stamp only costs this device a tie-break, not correctness.
+    }
+  }
 }

--- a/lib/providers/search_provider.dart
+++ b/lib/providers/search_provider.dart
@@ -23,10 +23,6 @@ final searchProvider = FutureProvider.autoDispose
       Future<void>.delayed(
         const Duration(minutes: 5),
       ).then((_) => link.close());
-      // One analytics call per distinct (debounced) query — the family key
-      // dedupes naturally because the same query gets the same cached
-      // FutureProvider instance.
-      if (query.trim().isNotEmpty) {}
       final api = ref.watch(sunohApiProvider);
       return api.fetchSearch(query);
     });

--- a/lib/providers/search_provider.dart
+++ b/lib/providers/search_provider.dart
@@ -26,8 +26,7 @@ final searchProvider = FutureProvider.autoDispose
       // One analytics call per distinct (debounced) query — the family key
       // dedupes naturally because the same query gets the same cached
       // FutureProvider instance.
-      if (query.trim().isNotEmpty) {
-      }
+      if (query.trim().isNotEmpty) {}
       final api = ref.watch(sunohApiProvider);
       return api.fetchSearch(query);
     });

--- a/lib/providers/sync_provider.dart
+++ b/lib/providers/sync_provider.dart
@@ -1,0 +1,20 @@
+// Riverpod surface for library sync.
+//
+// A ChangeNotifier because sync has more states than loading/loaded: it can be
+// off, configured but never run, syncing, or blocked because the folder grant
+// was revoked, and each needs something different said to the user.
+
+import 'package:flutter/widgets.dart';
+import 'package:flutter_riverpod/legacy.dart';
+
+import '../audio/audio_repo.dart';
+import '../sync/sync_service.dart';
+
+final syncProvider = ChangeNotifierProvider<SyncService>((ref) {
+  final repo = ref.watch(audioRepoProvider);
+  final service = SyncService(library: repo.library, settings: repo.settings);
+  // Restore configuration off the first frame; a folder behind a cloud
+  // provider can block for a moment and must not stall the build that made it.
+  WidgetsBinding.instance.addPostFrameCallback((_) => service.restore());
+  return service;
+});

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -26,6 +26,7 @@ import '../screens/home_screen.dart';
 import '../screens/library_screen.dart';
 import '../screens/liked_songs_screen.dart';
 import '../screens/local_collection_screen.dart';
+import '../screens/local_folders_screen.dart';
 import '../screens/local_library_screen.dart';
 import '../screens/podcast_categories_screen.dart';
 import '../screens/podcast_category_screen.dart';
@@ -238,6 +239,10 @@ List<RouteBase> _detailRoutes() => [
   GoRoute(
     path: 'local',
     pageBuilder: (c, s) => _slideRight(const LocalLibraryScreen(), s),
+  ),
+  GoRoute(
+    path: 'local-folders',
+    pageBuilder: (c, s) => _slideRight(const LocalFoldersScreen(), s),
   ),
   GoRoute(
     // `kind` is album|artist. The id is the grouping key, which embeds the
@@ -490,6 +495,9 @@ extension SunohNav on BuildContext {
 
   /// The on-device music library.
   void openLocalLibrary() => push('$_branchPrefix/local');
+
+  /// Which device folders count as music.
+  void openLocalFolders() => push('$_branchPrefix/local-folders');
 
   /// Library sync setup and status.
   void openSync() => push('$_branchPrefix/sync');

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -35,6 +35,7 @@ import '../screens/search_screen.dart';
 import '../screens/section_screen.dart';
 import '../screens/settings_screen.dart';
 import '../screens/spotify_import_screen.dart';
+import '../screens/sync_screen.dart';
 import '../screens/user_playlist_screen.dart';
 import '../screens/ytmusic_screens.dart';
 import '../shell/app_scaffold.dart';
@@ -48,7 +49,7 @@ GoRouter buildRouter() {
   return GoRouter(
     navigatorKey: rootNavigatorKey,
     initialLocation: '/home',
-        // Safety net for inbound Android Intents. The platform forwards the
+    // Safety net for inbound Android Intents. The platform forwards the
     // URI's path component to go_router *before* DeepLinkRouter (which
     // lives on top of app_links) gets a chance. Custom-scheme deep links
     // like `sunoh://playlist/abc` get parsed by Flutter as path `/abc`
@@ -229,6 +230,10 @@ List<RouteBase> _detailRoutes() => [
   GoRoute(
     path: 'history',
     pageBuilder: (c, s) => _slideRight(const RecentlyPlayedScreen(), s),
+  ),
+  GoRoute(
+    path: 'sync',
+    pageBuilder: (c, s) => _slideRight(const SyncScreen(), s),
   ),
   GoRoute(
     path: 'local',
@@ -485,6 +490,9 @@ extension SunohNav on BuildContext {
 
   /// The on-device music library.
   void openLocalLibrary() => push('$_branchPrefix/local');
+
+  /// Library sync setup and status.
+  void openSync() => push('$_branchPrefix/sync');
 
   /// One on-device album or artist.
   void openLocalCollection(String id, {required bool album}) => push(

--- a/lib/screens/local_folders_screen.dart
+++ b/lib/screens/local_folders_screen.dart
@@ -1,0 +1,422 @@
+// Which folders the on-device library takes music from.
+//
+// A phone's audio is not all music: notification tones, voice notes, WhatsApp
+// audio and podcast downloads from another app all land in MediaStore and all
+// show up in the library. MediaStore's IS_MUSIC flag and the duration floor
+// catch some of it, and nothing catches a folder of forwarded voice notes that
+// happen to be four minutes long.
+//
+// Choosing folders rather than excluding them. Both express the same thing,
+// but a real library is a hundred album folders under one parent: "use this
+// one" is a tap, and "not those ninety-nine" is not. Picking nothing means the
+// whole device, so a fresh install works without ever opening this screen.
+//
+// A chosen folder covers everything inside it, and the list is ordered and
+// indented by path so a parent sits directly above the folders it covers.
+// Folders already covered are shown checked but not tappable — untangling
+// them would mean choosing every sibling instead, which is the mess this
+// screen exists to avoid.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:solar_icons/solar_icons.dart';
+
+import '../api/local_media_channel.dart';
+import '../audio/local_library.dart';
+import '../providers/app_state_provider.dart';
+import '../providers/local_library_provider.dart';
+import '../state/app_state.dart';
+import '../theme/tokens.dart';
+import '../widgets/ui.dart';
+
+class LocalFoldersScreen extends ConsumerStatefulWidget {
+  const LocalFoldersScreen({super.key});
+
+  @override
+  ConsumerState<LocalFoldersScreen> createState() => _LocalFoldersScreenState();
+}
+
+class _LocalFoldersScreenState extends ConsumerState<LocalFoldersScreen> {
+  /// Roots staged for the next apply. Null until there is a scan to read, so a
+  /// scan still in flight cannot seed an empty selection that then looks like
+  /// a deliberate choice.
+  Set<String>? _staged;
+
+  static bool _same(Set<String> a, Set<String> b) =>
+      a.length == b.length && a.containsAll(b);
+
+  @override
+  Widget build(BuildContext context) {
+    final s = ref.watch(appStateProvider);
+    final c = s.colors;
+    final lib = ref.watch(localLibraryProvider);
+    final rows = _rows(lib.folders);
+
+    final staged = _staged ??= {...lib.includedFolders};
+    final dirty = !_same(staged, lib.includedFolders);
+
+    return ColoredBox(
+      color: c.bg,
+      child: Column(
+        children: [
+          _Header(
+            colors: c,
+            scanning: lib.isScanning,
+            everything: staged.isEmpty,
+            onUseEverything: staged.isEmpty
+                ? null
+                : () => setState(() => _staged = <String>{}),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 4, 20, 14),
+            child: Text(
+              staged.isEmpty
+                  ? 'Using every folder on this device. Choose one or more to '
+                        'narrow it down — a folder brings everything inside it.'
+                  : staged.length == 1
+                  ? '1 folder chosen, and everything inside it.'
+                  : '${staged.length} folders chosen, and everything inside '
+                        'them.',
+              style: SunohType.sans(
+                fontSize: 13,
+                color: c.fgMute,
+                height: 1.45,
+              ),
+            ),
+          ),
+          Expanded(
+            child: rows.isEmpty
+                ? Center(
+                    child: Text(
+                      lib.isScanning
+                          ? 'Scanning…'
+                          : 'No music folders found on this device.',
+                      style: SunohType.sans(fontSize: 13, color: c.fgMute),
+                    ),
+                  )
+                : ListView.builder(
+                    padding: EdgeInsets.only(bottom: dirty ? 8 : 140),
+                    itemCount: rows.length,
+                    itemBuilder: (context, i) {
+                      final row = rows[i];
+                      final chosen = staged.contains(row.folder.path);
+                      final covered =
+                          !chosen &&
+                          staged.isNotEmpty &&
+                          isUnderAnyRoot(row.folder.path, staged);
+                      return _FolderRow(
+                        row: row,
+                        colors: c,
+                        // Nothing chosen means everything is in, but the rows
+                        // are not "chosen": showing them all ticked would make
+                        // "Use everything" look like it did nothing.
+                        state: chosen
+                            ? _Pick.chosen
+                            : covered
+                            ? _Pick.covered
+                            : _Pick.off,
+                        onTap: covered
+                            ? null
+                            : () => setState(() {
+                                final next = {...staged};
+                                if (!next.remove(row.folder.path)) {
+                                  // Drop anything this folder now covers, so
+                                  // the set stays the shortest description of
+                                  // the same choice.
+                                  next.removeWhere(
+                                    (p) => isUnderAnyRoot(p, {row.folder.path}),
+                                  );
+                                  next.add(row.folder.path);
+                                }
+                                _staged = next;
+                              }),
+                      );
+                    },
+                  ),
+          ),
+          if (dirty)
+            _ApplyBar(
+              colors: c,
+              busy: lib.isScanning,
+              onApply: () => _apply(lib, s, staged),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _apply(LocalLibrary lib, AppState s, Set<String> staged) async {
+    await lib.setIncludedFolders(staged);
+    if (!mounted) return;
+    // Re-seed from what actually landed, so the bar clears only once the
+    // library really matches the choice.
+    setState(() => _staged = null);
+    s.flashToast(
+      staged.isEmpty
+          ? 'Using every folder'
+          : 'Using ${staged.length} folder${staged.length == 1 ? '' : 's'}',
+    );
+  }
+
+  /// Order by path so a parent sits directly above what it contains, and give
+  /// each row its depth relative to the other folders actually present — the
+  /// absolute path depth would indent everything off the screen.
+  static List<_Row> _rows(List<LocalFolder> folders) {
+    final sorted = [...folders]..sort((a, b) => a.path.compareTo(b.path));
+    return [
+      for (final f in sorted)
+        _Row(
+          folder: f,
+          depth: sorted
+              .where((o) => o.path != f.path && f.path.startsWith('${o.path}/'))
+              .length,
+        ),
+    ];
+  }
+}
+
+class _Row {
+  const _Row({required this.folder, required this.depth});
+  final LocalFolder folder;
+  final int depth;
+}
+
+enum _Pick { chosen, covered, off }
+
+class _Header extends StatelessWidget {
+  const _Header({
+    required this.colors,
+    required this.scanning,
+    required this.everything,
+    required this.onUseEverything,
+  });
+
+  final SunohColors colors;
+  final bool scanning;
+  final bool everything;
+  final VoidCallback? onUseEverything;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    return Padding(
+      padding: EdgeInsets.fromLTRB(
+        20,
+        MediaQuery.of(context).padding.top + 20,
+        20,
+        6,
+      ),
+      child: Row(
+        children: [
+          IconBtn(
+            icon: SolarIconsOutline.altArrowLeft,
+            color: c.fgDim,
+            size: 18,
+            onTap: () => context.pop(),
+          ),
+          const SizedBox(width: 4),
+          Expanded(
+            child: Text(
+              'Music folders',
+              style: SunohType.heading(
+                fontSize: 24,
+                color: c.fg,
+                letterSpacing: -0.4,
+              ),
+            ),
+          ),
+          if (scanning)
+            SizedBox(
+              width: 16,
+              height: 16,
+              child: CircularProgressIndicator(strokeWidth: 2, color: c.fgMute),
+            )
+          else if (!everything)
+            GestureDetector(
+              onTap: onUseEverything,
+              behavior: HitTestBehavior.opaque,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
+                child: Text(
+                  'Use everything',
+                  style: SunohType.sans(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: c.accent,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FolderRow extends StatelessWidget {
+  const _FolderRow({
+    required this.row,
+    required this.state,
+    required this.colors,
+    required this.onTap,
+  });
+
+  final _Row row;
+  final _Pick state;
+  final SunohColors colors;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    final folder = row.folder;
+    final dim = state == _Pick.off;
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Padding(
+        // Indent is capped: a deeply nested folder still needs room for its
+        // name, and past a few levels the extra offset stops meaning anything.
+        padding: EdgeInsets.fromLTRB(
+          20.0 + 18 * row.depth.clamp(0, 4),
+          10,
+          20,
+          10,
+        ),
+        child: Row(
+          children: [
+            _Check(state: state, colors: c),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    folder.name.isEmpty ? folder.path : folder.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: SunohType.sans(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                      color: dim ? c.fgMute : c.fg,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    // Where it sits, not the whole path: two folders can share
+                    // a name, and picking the wrong one silently hides the
+                    // wrong music.
+                    state == _Pick.covered
+                        ? 'Included with the folder above'
+                        : folderLocation(folder.path),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: SunohType.sans(fontSize: 11.5, color: c.fgMute),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 10),
+            Text(
+              '${folder.trackCount}',
+              style: SunohType.mono(fontSize: 12, color: c.fgMute),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Check extends StatelessWidget {
+  const _Check({required this.state, required this.colors});
+  final _Pick state;
+  final SunohColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    final on = state != _Pick.off;
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 140),
+      curve: Curves.easeOut,
+      width: 22,
+      height: 22,
+      decoration: BoxDecoration(
+        // A covered folder is in the library but was not picked, so it reads
+        // as a quieter version of the same tick rather than a second control.
+        color: switch (state) {
+          _Pick.chosen => c.accent,
+          _Pick.covered => c.accent.withValues(alpha: 0.28),
+          _Pick.off => Colors.transparent,
+        },
+        shape: BoxShape.circle,
+        border: on ? null : Border.all(color: c.line, width: 1.5),
+      ),
+      child: on
+          ? Icon(
+              Icons.check_rounded,
+              size: 15,
+              color: state == _Pick.chosen ? c.onAccent : c.fgDim,
+            )
+          : null,
+    );
+  }
+}
+
+/// Floats above the mini player rather than sitting flush at the bottom: the
+/// player and nav bar are drawn over every screen's last 140 logical pixels, so
+/// a flush bar is invisible exactly when it matters.
+class _ApplyBar extends StatelessWidget {
+  const _ApplyBar({
+    required this.colors,
+    required this.busy,
+    required this.onApply,
+  });
+
+  final SunohColors colors;
+  final bool busy;
+  final Future<void> Function() onApply;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 8, 16, 148),
+      padding: const EdgeInsets.fromLTRB(16, 12, 12, 12),
+      decoration: squircleDecoration(
+        radius: 16,
+        color: c.surface,
+        borderColor: c.line,
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              'Your library will be rescanned.',
+              style: SunohType.sans(fontSize: 12.5, color: c.fgMute),
+            ),
+          ),
+          GestureDetector(
+            onTap: busy ? null : onApply,
+            behavior: HitTestBehavior.opaque,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+              decoration: squircleDecoration(radius: 999, color: c.accent),
+              child: Text(
+                busy ? 'Applying…' : 'Apply',
+                style: SunohType.sans(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: c.onAccent,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/local_folders_screen.dart
+++ b/lib/screens/local_folders_screen.dart
@@ -6,16 +6,20 @@
 // catch some of it, and nothing catches a folder of forwarded voice notes that
 // happen to be four minutes long.
 //
-// Choosing folders rather than excluding them. Both express the same thing,
-// but a real library is a hundred album folders under one parent: "use this
-// one" is a tap, and "not those ninety-nine" is not. Picking nothing means the
-// whole device, so a fresh install works without ever opening this screen.
+// The screen is a tree with a row for the device itself at the top. Every
+// folder follows the one above it until you say otherwise, so the two things
+// people actually want are each a couple of taps: keep everything but the
+// ringtones (leave the top row on, turn one folder off), or take only one
+// library (turn the top row off, turn that folder on). See [FolderRules] for
+// why one rule beats an include list or an exclude list.
 //
-// A chosen folder covers everything inside it, and the list is ordered and
-// indented by path so a parent sits directly above the folders it covers.
-// Folders already covered are shown checked but not tappable — untangling
-// them would mean choosing every sibling instead, which is the mess this
-// screen exists to avoid.
+// Rows are ordered and indented by path so a folder sits directly under the
+// one it inherits from, and the count on the right is every track in that
+// folder whether it is currently taken or not.
+//
+// The selection applies in one go. Six folders is one decision, and applying
+// each separately would rescan the library six times, five of those showing a
+// state nobody asked for.
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -38,23 +42,35 @@ class LocalFoldersScreen extends ConsumerStatefulWidget {
 }
 
 class _LocalFoldersScreenState extends ConsumerState<LocalFoldersScreen> {
-  /// Roots staged for the next apply. Null until there is a scan to read, so a
-  /// scan still in flight cannot seed an empty selection that then looks like
-  /// a deliberate choice.
-  Set<String>? _staged;
+  /// Rules staged for the next apply. Null until there is a scan to read, so a
+  /// scan still in flight cannot seed a choice nobody made.
+  FolderRules? _staged;
 
-  static bool _same(Set<String> a, Set<String> b) =>
-      a.length == b.length && a.containsAll(b);
+  /// Rows are derived from the folder list, which only changes on a rescan, so
+  /// they are built once per scan rather than on every frame — see the
+  /// no-work-in-`build` rule. [LocalLibrary.folders] hands back the same list
+  /// instance until a rescan replaces it, which is what makes the identity
+  /// check sound.
+  List<LocalFolder>? _rowsFor;
+  List<_Row> _rows = const [];
+
+  List<_Row> _rowsOf(List<LocalFolder> folders) {
+    if (identical(folders, _rowsFor)) return _rows;
+    _rowsFor = folders;
+    return _rows = _tree(folders);
+  }
 
   @override
   Widget build(BuildContext context) {
     final s = ref.watch(appStateProvider);
     final c = s.colors;
     final lib = ref.watch(localLibraryProvider);
-    final rows = _rows(lib.folders);
+    final rows = _rowsOf(lib.folders);
 
-    final staged = _staged ??= {...lib.includedFolders};
-    final dirty = !_same(staged, lib.includedFolders);
+    final staged = _staged ??= lib.folderRules;
+    final dirty = !staged.sameAs(lib.folderRules);
+    final kept = rows.where((r) => staged.allows(r.folder.path));
+    final tracks = kept.fold<int>(0, (n, r) => n + r.folder.trackCount);
 
     return ColoredBox(
       color: c.bg,
@@ -63,21 +79,14 @@ class _LocalFoldersScreenState extends ConsumerState<LocalFoldersScreen> {
           _Header(
             colors: c,
             scanning: lib.isScanning,
-            everything: staged.isEmpty,
-            onUseEverything: staged.isEmpty
-                ? null
-                : () => setState(() => _staged = <String>{}),
+            canReset: !staged.isDefault,
+            onReset: () => setState(() => _staged = const FolderRules()),
           ),
           Padding(
             padding: const EdgeInsets.fromLTRB(20, 4, 20, 14),
             child: Text(
-              staged.isEmpty
-                  ? 'Using every folder on this device. Choose one or more to '
-                        'narrow it down — a folder brings everything inside it.'
-                  : staged.length == 1
-                  ? '1 folder chosen, and everything inside it.'
-                  : '${staged.length} folders chosen, and everything inside '
-                        'them.',
+              'Turn a folder off to leave it out. Everything inside it follows '
+              'unless you turn one back on.',
               style: SunohType.sans(
                 fontSize: 13,
                 color: c.fgMute,
@@ -97,42 +106,20 @@ class _LocalFoldersScreenState extends ConsumerState<LocalFoldersScreen> {
                   )
                 : ListView.builder(
                     padding: EdgeInsets.only(bottom: dirty ? 8 : 140),
-                    itemCount: rows.length,
-                    itemBuilder: (context, i) {
-                      final row = rows[i];
-                      final chosen = staged.contains(row.folder.path);
-                      final covered =
-                          !chosen &&
-                          staged.isNotEmpty &&
-                          isUnderAnyRoot(row.folder.path, staged);
-                      return _FolderRow(
-                        row: row,
-                        colors: c,
-                        // Nothing chosen means everything is in, but the rows
-                        // are not "chosen": showing them all ticked would make
-                        // "Use everything" look like it did nothing.
-                        state: chosen
-                            ? _Pick.chosen
-                            : covered
-                            ? _Pick.covered
-                            : _Pick.off,
-                        onTap: covered
-                            ? null
-                            : () => setState(() {
-                                final next = {...staged};
-                                if (!next.remove(row.folder.path)) {
-                                  // Drop anything this folder now covers, so
-                                  // the set stays the shortest description of
-                                  // the same choice.
-                                  next.removeWhere(
-                                    (p) => isUnderAnyRoot(p, {row.folder.path}),
-                                  );
-                                  next.add(row.folder.path);
-                                }
-                                _staged = next;
-                              }),
-                      );
-                    },
+                    // One extra for the device row the folders hang off.
+                    itemCount: rows.length + 1,
+                    itemBuilder: (context, i) => i == 0
+                        ? _DeviceRow(
+                            colors: c,
+                            on: staged.defaultIncluded,
+                            tracks: tracks,
+                            onTap: () => setState(() {
+                              _staged = staged.withDefault(
+                                included: !staged.defaultIncluded,
+                              );
+                            }),
+                          )
+                        : _rowFor(rows[i - 1], staged, c),
                   ),
           ),
           if (dirty)
@@ -146,33 +133,49 @@ class _LocalFoldersScreenState extends ConsumerState<LocalFoldersScreen> {
     );
   }
 
-  Future<void> _apply(LocalLibrary lib, AppState s, Set<String> staged) async {
-    await lib.setIncludedFolders(staged);
+  Widget _rowFor(_Row row, FolderRules staged, SunohColors c) {
+    final path = row.folder.path;
+    final on = staged.allows(path);
+    return _FolderRow(
+      row: row,
+      colors: c,
+      on: on,
+      // An explicit rule is drawn solid so a folder someone deliberately set
+      // is distinguishable from one that merely follows its parent — otherwise
+      // there is no way to see what you have actually decided.
+      explicit: staged.overrides.containsKey(path),
+      onTap: () => setState(() => _staged = staged.set(path, included: !on)),
+    );
+  }
+
+  Future<void> _apply(LocalLibrary lib, AppState s, FolderRules staged) async {
+    await lib.setFolderRules(staged);
     if (!mounted) return;
     // Re-seed from what actually landed, so the bar clears only once the
     // library really matches the choice.
     setState(() => _staged = null);
-    s.flashToast(
-      staged.isEmpty
-          ? 'Using every folder'
-          : 'Using ${staged.length} folder${staged.length == 1 ? '' : 's'}',
-    );
+    s.flashToast(staged.isDefault ? 'Using every folder' : 'Folders updated');
   }
 
-  /// Order by path so a parent sits directly above what it contains, and give
-  /// each row its depth relative to the other folders actually present — the
-  /// absolute path depth would indent everything off the screen.
-  static List<_Row> _rows(List<LocalFolder> folders) {
+  /// Order by path so a folder sits directly below the one it inherits from,
+  /// and give each row its depth among the folders actually present — absolute
+  /// path depth would indent everything off the screen.
+  ///
+  /// One pass with a stack of open ancestors rather than counting ancestors per
+  /// row: the counting version is quadratic, which is invisible on a phone with
+  /// twenty folders and is not on one with a thousand.
+  static List<_Row> _tree(List<LocalFolder> folders) {
     final sorted = [...folders]..sort((a, b) => a.path.compareTo(b.path));
-    return [
-      for (final f in sorted)
-        _Row(
-          folder: f,
-          depth: sorted
-              .where((o) => o.path != f.path && f.path.startsWith('${o.path}/'))
-              .length,
-        ),
-    ];
+    final open = <String>[];
+    final rows = <_Row>[];
+    for (final f in sorted) {
+      while (open.isNotEmpty && !f.path.startsWith('${open.last}/')) {
+        open.removeLast();
+      }
+      rows.add(_Row(folder: f, depth: open.length));
+      open.add(f.path);
+    }
+    return rows;
   }
 }
 
@@ -182,20 +185,18 @@ class _Row {
   final int depth;
 }
 
-enum _Pick { chosen, covered, off }
-
 class _Header extends StatelessWidget {
   const _Header({
     required this.colors,
     required this.scanning,
-    required this.everything,
-    required this.onUseEverything,
+    required this.canReset,
+    required this.onReset,
   });
 
   final SunohColors colors;
   final bool scanning;
-  final bool everything;
-  final VoidCallback? onUseEverything;
+  final bool canReset;
+  final VoidCallback onReset;
 
   @override
   Widget build(BuildContext context) {
@@ -232,14 +233,14 @@ class _Header extends StatelessWidget {
               height: 16,
               child: CircularProgressIndicator(strokeWidth: 2, color: c.fgMute),
             )
-          else if (!everything)
+          else if (canReset)
             GestureDetector(
-              onTap: onUseEverything,
+              onTap: onReset,
               behavior: HitTestBehavior.opaque,
               child: Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 6),
                 child: Text(
-                  'Use everything',
+                  'Reset',
                   style: SunohType.sans(
                     fontSize: 13,
                     fontWeight: FontWeight.w600,
@@ -254,24 +255,88 @@ class _Header extends StatelessWidget {
   }
 }
 
+/// The device itself, at the top of the tree. Every folder falls back to this,
+/// including folders that do not exist yet — which is the whole reason it is a
+/// row you can see and set rather than a hidden default.
+class _DeviceRow extends StatelessWidget {
+  const _DeviceRow({
+    required this.colors,
+    required this.on,
+    required this.tracks,
+    required this.onTap,
+  });
+
+  final SunohColors colors;
+  final bool on;
+  final int tracks;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(20, 10, 20, 14),
+        child: Row(
+          children: [
+            _Check(on: on, explicit: true, colors: c),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'All music on this device',
+                    style: SunohType.sans(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w600,
+                      color: c.fg,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    on
+                        ? 'New folders are included'
+                        : 'New folders are left out',
+                    style: SunohType.sans(fontSize: 11.5, color: c.fgMute),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(width: 10),
+            Text(
+              '$tracks',
+              style: SunohType.mono(fontSize: 12, color: c.fgDim),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
 class _FolderRow extends StatelessWidget {
   const _FolderRow({
     required this.row,
-    required this.state,
+    required this.on,
+    required this.explicit,
     required this.colors,
     required this.onTap,
   });
 
   final _Row row;
-  final _Pick state;
+  final bool on;
+  final bool explicit;
   final SunohColors colors;
-  final VoidCallback? onTap;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final c = colors;
     final folder = row.folder;
-    final dim = state == _Pick.off;
     return GestureDetector(
       onTap: onTap,
       behavior: HitTestBehavior.opaque,
@@ -279,14 +344,14 @@ class _FolderRow extends StatelessWidget {
         // Indent is capped: a deeply nested folder still needs room for its
         // name, and past a few levels the extra offset stops meaning anything.
         padding: EdgeInsets.fromLTRB(
-          20.0 + 18 * row.depth.clamp(0, 4),
+          20.0 + 18 * (row.depth + 1).clamp(0, 4),
           10,
           20,
           10,
         ),
         child: Row(
           children: [
-            _Check(state: state, colors: c),
+            _Check(on: on, explicit: explicit, colors: c),
             const SizedBox(width: 14),
             Expanded(
               child: Column(
@@ -300,7 +365,7 @@ class _FolderRow extends StatelessWidget {
                     style: SunohType.sans(
                       fontSize: 14,
                       fontWeight: FontWeight.w500,
-                      color: dim ? c.fgMute : c.fg,
+                      color: on ? c.fg : c.fgMute,
                     ),
                   ),
                   const SizedBox(height: 2),
@@ -308,9 +373,7 @@ class _FolderRow extends StatelessWidget {
                     // Where it sits, not the whole path: two folders can share
                     // a name, and picking the wrong one silently hides the
                     // wrong music.
-                    state == _Pick.covered
-                        ? 'Included with the folder above'
-                        : folderLocation(folder.path),
+                    folderLocation(folder.path),
                     maxLines: 1,
                     overflow: TextOverflow.ellipsis,
                     style: SunohType.sans(fontSize: 11.5, color: c.fgMute),
@@ -330,38 +393,53 @@ class _FolderRow extends StatelessWidget {
   }
 }
 
+/// Four states in one control: in or out, each either set here or inherited.
+/// Inherited reads as a faded version of the same mark rather than as a third
+/// symbol, because it is the same answer — just decided further up.
 class _Check extends StatelessWidget {
-  const _Check({required this.state, required this.colors});
-  final _Pick state;
+  const _Check({
+    required this.on,
+    required this.explicit,
+    required this.colors,
+  });
+
+  final bool on;
+  final bool explicit;
   final SunohColors colors;
 
   @override
   Widget build(BuildContext context) {
     final c = colors;
-    final on = state != _Pick.off;
     return AnimatedContainer(
       duration: const Duration(milliseconds: 140),
       curve: Curves.easeOut,
       width: 22,
       height: 22,
       decoration: BoxDecoration(
-        // A covered folder is in the library but was not picked, so it reads
-        // as a quieter version of the same tick rather than a second control.
-        color: switch (state) {
-          _Pick.chosen => c.accent,
-          _Pick.covered => c.accent.withValues(alpha: 0.28),
-          _Pick.off => Colors.transparent,
-        },
+        color: on
+            ? (explicit ? c.accent : c.accent.withValues(alpha: 0.28))
+            : Colors.transparent,
         shape: BoxShape.circle,
-        border: on ? null : Border.all(color: c.line, width: 1.5),
+        border: on
+            ? null
+            : Border.all(
+                color: explicit ? c.fgMute : c.line,
+                width: explicit ? 1.8 : 1.5,
+              ),
       ),
       child: on
           ? Icon(
               Icons.check_rounded,
               size: 15,
-              color: state == _Pick.chosen ? c.onAccent : c.fgDim,
+              color: explicit ? c.onAccent : c.fgDim,
             )
-          : null,
+          // A folder turned off here gets a mark of its own, so a deliberate
+          // exclusion is not mistaken for one that just follows its parent.
+          : (explicit
+                ? Center(
+                    child: Container(width: 9, height: 1.8, color: c.fgMute),
+                  )
+                : null),
     );
   }
 }

--- a/lib/screens/local_library_screen.dart
+++ b/lib/screens/local_library_screen.dart
@@ -155,13 +155,20 @@ class _Header extends StatelessWidget {
               height: 16,
               child: CircularProgressIndicator(strokeWidth: 2, color: c.fgMute),
             )
-          else
+          else ...[
+            IconBtn(
+              icon: SolarIconsOutline.folder,
+              color: c.fgDim,
+              size: 18,
+              onTap: () => context.openLocalFolders(),
+            ),
             IconBtn(
               icon: SolarIconsOutline.refresh,
               color: c.fgDim,
               size: 18,
               onTap: () => library.load(force: true),
             ),
+          ],
         ],
       ),
     );

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -21,6 +21,7 @@ import '../providers/app_state_provider.dart';
 import '../providers/languages_provider.dart';
 import '../providers/update_provider.dart';
 import '../providers/ytmusic_provider.dart';
+import '../router/router.dart';
 import '../state/app_state.dart';
 import '../theme/tokens.dart';
 import '../widgets/ui.dart';
@@ -143,6 +144,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
             colors: c,
             scale: scale,
             rows: [
+              _NavRow(
+                label: 'Sync',
+                summary: 'Keep two phones in step',
+                onTap: () => context.openSync(),
+                colors: c,
+              ),
               _RadioRow<SunohTheme>(
                 label: 'Theme',
                 value: s.theme,

--- a/lib/screens/sync_screen.dart
+++ b/lib/screens/sync_screen.dart
@@ -1,0 +1,398 @@
+// Library sync setup and status.
+//
+// Two paths in: set up a new folder (this device generates the key and shows
+// it once), or join an existing one (enter the code from the first device).
+// Both then pick a folder with the system picker.
+//
+// The recovery code is the only thing that can decrypt the folder, and it is
+// never sent anywhere. If it is lost, the files in the folder are unreadable —
+// that is the point, and the screen says so rather than burying it.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:solar_icons/solar_icons.dart';
+
+import '../providers/app_state_provider.dart';
+import '../providers/sync_provider.dart';
+import '../sync/sync_service.dart';
+import '../theme/tokens.dart';
+import '../widgets/ui.dart';
+
+class SyncScreen extends ConsumerStatefulWidget {
+  const SyncScreen({super.key});
+  @override
+  ConsumerState<SyncScreen> createState() => _SyncScreenState();
+}
+
+class _SyncScreenState extends ConsumerState<SyncScreen> {
+  final _codeController = TextEditingController();
+  bool _busy = false;
+  String? _revealedCode;
+
+  @override
+  void dispose() {
+    _codeController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _run(Future<void> Function() action) async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    try {
+      await action();
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final s = ref.watch(appStateProvider);
+    final c = s.colors;
+    final sync = ref.watch(syncProvider);
+
+    return ColoredBox(
+      color: c.bg,
+      child: ListView(
+        padding: EdgeInsets.only(
+          top: MediaQuery.of(context).padding.top + 20,
+          bottom: 140,
+        ),
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 8),
+            child: Row(
+              children: [
+                IconBtn(
+                  icon: SolarIconsOutline.altArrowLeft,
+                  color: c.fgDim,
+                  size: 18,
+                  onTap: () => context.pop(),
+                ),
+                const SizedBox(width: 4),
+                Text(
+                  'Sync',
+                  style: SunohType.heading(
+                    fontSize: 24,
+                    color: c.fg,
+                    letterSpacing: -0.4,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20, 8, 20, 20),
+            child: Text(
+              'Keep liked songs, playlists and settings the same on two '
+              'phones. sunoh writes an encrypted file into a folder you '
+              'choose. Whatever syncs that folder moves it. There is no '
+              'account and nothing is sent to us.',
+              style: SunohType.sans(fontSize: 13, color: c.fgMute, height: 1.5),
+            ),
+          ),
+          if (sync.isConfigured)
+            _Configured(sync: sync, colors: c, busy: _busy, run: _run)
+          else
+            _Setup(
+              colors: c,
+              busy: _busy,
+              controller: _codeController,
+              onSetUp: () => _run(() async {
+                final code = await sync.setUp();
+                if (code != null && mounted) {
+                  setState(() => _revealedCode = code);
+                }
+              }),
+              onJoin: () => _run(() async {
+                final ok = await sync.joinWithCode(_codeController.text);
+                if (!mounted) return;
+                s.flashToast(
+                  ok ? 'Synced' : 'Could not read that folder with this code',
+                );
+              }),
+            ),
+          if (_revealedCode != null)
+            _RecoveryCode(code: _revealedCode!, colors: c),
+        ],
+      ),
+    );
+  }
+}
+
+class _Setup extends StatelessWidget {
+  const _Setup({
+    required this.colors,
+    required this.busy,
+    required this.controller,
+    required this.onSetUp,
+    required this.onJoin,
+  });
+  final SunohColors colors;
+  final bool busy;
+  final TextEditingController controller;
+  final VoidCallback onSetUp;
+  final VoidCallback onJoin;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: _Card(
+            colors: c,
+            title: 'Set up on this phone',
+            body:
+                'Pick a folder that already syncs between your devices, such '
+                'as a Syncthing, Nextcloud or Drive folder. You will get a '
+                'recovery code to enter on the second phone.',
+            action: busy ? 'Working…' : 'Choose folder',
+            onTap: busy ? null : onSetUp,
+            filled: true,
+          ),
+        ),
+        const SizedBox(height: 14),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20),
+          child: _Card(
+            colors: c,
+            title: 'Join from another phone',
+            body:
+                'Enter the recovery code from the phone you set up first, '
+                'then pick the same folder.',
+            child: TextField(
+              controller: controller,
+              autocorrect: false,
+              enableSuggestions: false,
+              style: SunohType.mono(fontSize: 13, color: c.fg),
+              decoration: InputDecoration(
+                hintText: 'Recovery code',
+                hintStyle: SunohType.mono(fontSize: 13, color: c.fgMute),
+                border: InputBorder.none,
+                isDense: true,
+                contentPadding: const EdgeInsets.symmetric(vertical: 8),
+              ),
+            ),
+            action: busy ? 'Working…' : 'Pick folder and join',
+            onTap: busy ? null : onJoin,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _Configured extends StatelessWidget {
+  const _Configured({
+    required this.sync,
+    required this.colors,
+    required this.busy,
+    required this.run,
+  });
+  final SyncService sync;
+  final SunohColors colors;
+  final bool busy;
+  final Future<void> Function(Future<void> Function()) run;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    final last = sync.lastSync;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _Card(
+            colors: c,
+            title: sync.folderName ?? 'Synced folder',
+            body: switch (sync.status) {
+              SyncStatus.noAccess =>
+                'Access to this folder was lost. Pick it again to carry on.',
+              SyncStatus.failed =>
+                'The last sync did not finish. It will try again.',
+              SyncStatus.syncing => 'Syncing…',
+              _ when last == null => 'Not synced yet.',
+              _ => 'Last synced ${_ago(last!)}.',
+            },
+            action: busy ? 'Syncing…' : 'Sync now',
+            onTap: busy
+                ? null
+                : () => run(() async {
+                    await sync.syncNow();
+                  }),
+            filled: true,
+          ),
+          const SizedBox(height: 14),
+          GestureDetector(
+            onTap: busy
+                ? null
+                : () => run(() async {
+                    await sync.disable();
+                  }),
+            behavior: HitTestBehavior.opaque,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 10),
+              child: Text(
+                'Stop syncing on this phone',
+                style: SunohType.sans(fontSize: 13, color: c.fgMute),
+              ),
+            ),
+          ),
+          Text(
+            'Your library stays on this phone. Only this device\'s file is '
+            'removed from the folder.',
+            style: SunohType.sans(fontSize: 12, color: c.fgMute, height: 1.4),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _ago(DateTime t) {
+    final d = DateTime.now().difference(t);
+    if (d.inMinutes < 1) return 'just now';
+    if (d.inHours < 1) return '${d.inMinutes} min ago';
+    if (d.inDays < 1) return '${d.inHours} h ago';
+    return '${d.inDays} d ago';
+  }
+}
+
+/// Shown once, immediately after setup.
+class _RecoveryCode extends StatelessWidget {
+  const _RecoveryCode({required this.code, required this.colors});
+  final String code;
+  final SunohColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 18, 20, 0),
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: squircleDecoration(
+          radius: 14,
+          color: c.surface,
+          borderColor: c.accent,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            eyebrow('RECOVERY CODE', c.accent),
+            const SizedBox(height: 10),
+            SelectableText(
+              code,
+              style: SunohType.mono(fontSize: 13, color: c.fg, height: 1.5),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Enter this on your other phone. Keep a copy somewhere safe: it '
+              'is the only thing that can read the folder, it is never sent '
+              'anywhere, and it cannot be recovered if lost.',
+              style: SunohType.sans(
+                fontSize: 12,
+                color: c.fgMute,
+                height: 1.45,
+              ),
+            ),
+            const SizedBox(height: 12),
+            GestureDetector(
+              onTap: () => Clipboard.setData(ClipboardData(text: code)),
+              behavior: HitTestBehavior.opaque,
+              child: Text(
+                'Copy code',
+                style: SunohType.sans(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: c.accent,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Card extends StatelessWidget {
+  const _Card({
+    required this.colors,
+    required this.title,
+    required this.body,
+    required this.action,
+    required this.onTap,
+    this.child,
+    this.filled = false,
+  });
+  final SunohColors colors;
+  final String title;
+  final String body;
+  final String action;
+  final VoidCallback? onTap;
+  final Widget? child;
+  final bool filled;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: squircleDecoration(
+        radius: 14,
+        color: c.surface,
+        borderColor: c.line,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: SunohType.sans(
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+              color: c.fg,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            body,
+            style: SunohType.sans(
+              fontSize: 12.5,
+              color: c.fgMute,
+              height: 1.45,
+            ),
+          ),
+          if (child != null) ...[const SizedBox(height: 10), child!],
+          const SizedBox(height: 14),
+          GestureDetector(
+            onTap: onTap,
+            behavior: HitTestBehavior.opaque,
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 9),
+              decoration: squircleDecoration(
+                radius: 999,
+                color: filled ? c.accent : Colors.transparent,
+                borderColor: filled ? null : c.line,
+              ),
+              child: Text(
+                action,
+                style: SunohType.sans(
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                  color: filled ? c.onAccent : c.fg,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/sync_screen.dart
+++ b/lib/screens/sync_screen.dart
@@ -165,6 +165,8 @@ class _Setup extends StatelessWidget {
             body:
                 'Enter the recovery code from the phone you set up first, '
                 'then pick the same folder.',
+            action: busy ? 'Working…' : 'Pick folder and join',
+            onTap: busy ? null : onJoin,
             child: TextField(
               controller: controller,
               autocorrect: false,
@@ -178,8 +180,6 @@ class _Setup extends StatelessWidget {
                 contentPadding: const EdgeInsets.symmetric(vertical: 8),
               ),
             ),
-            action: busy ? 'Working…' : 'Pick folder and join',
-            onTap: busy ? null : onJoin,
           ),
         ),
       ],
@@ -218,7 +218,7 @@ class _Configured extends StatelessWidget {
                 'The last sync did not finish. It will try again.',
               SyncStatus.syncing => 'Syncing…',
               _ when last == null => 'Not synced yet.',
-              _ => 'Last synced ${_ago(last!)}.',
+              _ => 'Last synced ${_ago(last)}.',
             },
             action: busy ? 'Syncing…' : 'Sync now',
             onTap: busy

--- a/lib/share/share_link.dart
+++ b/lib/share/share_link.dart
@@ -15,7 +15,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:share_plus/share_plus.dart';
 
-
 const String _kBaseUrl = 'https://sunoh.online';
 
 /// Build the canonical share URL for a piece of content.

--- a/lib/sync/sync_channel.dart
+++ b/lib/sync/sync_channel.dart
@@ -1,0 +1,129 @@
+// Dart side of the sync bridge.
+//
+// The native half (android/.../sync/SyncBridge.kt) owns the Storage Access
+// Framework and AES-GCM. This is a thin wrapper: every method returns a
+// benign empty result rather than throwing, because a synced folder can be
+// unmounted, revoked, or mid-upload at any moment and none of that should
+// reach the user as an error.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+class SyncChannel {
+  SyncChannel._();
+  static final SyncChannel instance = SyncChannel._();
+
+  static const MethodChannel _channel = MethodChannel('codes.afk.sunoh/sync');
+
+  bool get _supported => defaultTargetPlatform == TargetPlatform.android;
+
+  /// Show the system folder picker. Null when the user backs out, which is a
+  /// normal outcome rather than a failure.
+  Future<String?> pickFolder() async {
+    if (!_supported) return null;
+    try {
+      return await _channel.invokeMethod<String>('pickFolder');
+    } on PlatformException catch (e) {
+      debugPrint('[sync] pickFolder failed: ${e.message}');
+      return null;
+    }
+  }
+
+  /// Whether the saved folder is still readable. The user can revoke the
+  /// grant from system settings, or the volume can disappear, so this is
+  /// checked before every sync rather than trusted from setup time.
+  Future<bool> hasAccess(String treeUri) async {
+    if (!_supported) return false;
+    try {
+      return await _channel.invokeMethod<bool>('hasAccess', {
+            'tree': treeUri,
+          }) ??
+          false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  Future<String?> folderName(String treeUri) async {
+    if (!_supported) return null;
+    try {
+      return await _channel.invokeMethod<String>('folderName', {
+        'tree': treeUri,
+      });
+    } on PlatformException {
+      return null;
+    }
+  }
+
+  /// A fresh random key, base64. Shown to the user once as a recovery code.
+  Future<String?> generateKey() async {
+    if (!_supported) return null;
+    try {
+      return await _channel.invokeMethod<String>('generateKey');
+    } on PlatformException {
+      return null;
+    }
+  }
+
+  /// Every sync file in the folder that decrypts with [key], as name to
+  /// plaintext bytes. Files written with another key are absent rather than
+  /// erroring: the folder may hold an unrelated setup's data.
+  Future<Map<String, Uint8List>> readAll({
+    required String treeUri,
+    required String key,
+  }) async {
+    if (!_supported) return {};
+    try {
+      final raw = await _channel.invokeMapMethod<String, Object?>('readAll', {
+        'tree': treeUri,
+        'key': key,
+      });
+      if (raw == null) return {};
+      final out = <String, Uint8List>{};
+      raw.forEach((name, bytes) {
+        if (bytes is Uint8List) out[name] = bytes;
+      });
+      return out;
+    } on PlatformException catch (e) {
+      debugPrint('[sync] readAll failed: ${e.message}');
+      return {};
+    }
+  }
+
+  /// Write this device's file, encrypted. Returns false on any failure, which
+  /// the caller treats as "try again next time" rather than surfacing.
+  Future<bool> write({
+    required String treeUri,
+    required String name,
+    required String key,
+    required Uint8List bytes,
+  }) async {
+    if (!_supported) return false;
+    try {
+      return await _channel.invokeMethod<bool>('write', {
+            'tree': treeUri,
+            'name': name,
+            'key': key,
+            'bytes': bytes,
+          }) ??
+          false;
+    } on PlatformException catch (e) {
+      debugPrint('[sync] write failed: ${e.message}');
+      return false;
+    }
+  }
+
+  /// Remove this device's own file, when the user turns sync off.
+  Future<bool> delete({required String treeUri, required String name}) async {
+    if (!_supported) return false;
+    try {
+      return await _channel.invokeMethod<bool>('delete', {
+            'tree': treeUri,
+            'name': name,
+          }) ??
+          false;
+    } on PlatformException {
+      return false;
+    }
+  }
+}

--- a/lib/sync/sync_merge.dart
+++ b/lib/sync/sync_merge.dart
@@ -1,0 +1,203 @@
+// Merging one device's library with another's.
+//
+// The whole feature turns on this file, and on one rule: a collection is a set
+// of records keyed by id, each carrying the time it was last touched and
+// whether that touch was an addition or a removal. Merging takes, per id, the
+// record with the newest timestamp.
+//
+// The naive alternative — union the two lists — is what makes cloud-synced
+// libraries resurrect deleted things. Unliking a song on one phone removes it
+// there; a union with the other phone, which still has it, puts it back, and
+// it comes back on both. Deletions have to be represented, not just absent,
+// which is what the tombstone is for.
+//
+// No Flutter import here: this is the part worth testing hardest, and it
+// should be testable without a widget tree.
+
+import '../api/dto.dart';
+
+/// When a record's state was last set, and whether it still exists.
+class SyncRecord {
+  const SyncRecord({required this.at, required this.deleted});
+
+  /// Milliseconds since epoch. Device clocks disagree, and that is tolerable:
+  /// the failure mode of a skewed clock is that one device's edit loses to an
+  /// older one, not corruption. Anything stronger (vector clocks, a Lamport
+  /// counter per device) buys correctness the user would never notice at this
+  /// scale and costs a schema nobody can debug.
+  final int at;
+
+  /// A tombstone. The item is gone, and this record says *when* it went, so a
+  /// later addition on another device still wins.
+  final bool deleted;
+
+  SyncRecord.alive(this.at) : deleted = false;
+  SyncRecord.tombstone(this.at) : deleted = true;
+
+  Map<String, dynamic> toJson() => {'at': at, if (deleted) 'del': true};
+
+  static SyncRecord? fromJson(Object? raw) {
+    if (raw is! Map) return null;
+    final at = (raw['at'] as num?)?.toInt();
+    if (at == null) return null;
+    return SyncRecord(at: at, deleted: raw['del'] == true);
+  }
+
+  /// The winning record for an id.
+  ///
+  /// Newest wins. On an exact tie a deletion wins, and that rule is load
+  /// bearing: preferring "whichever is mine" makes the merge depend on which
+  /// device runs it, so two phones merging the same pair reach opposite
+  /// answers and then write both back — the library flips state forever.
+  ///
+  /// Deletion is the right side of a tie because resurrecting a removed item
+  /// is the failure this whole file exists to prevent, and a tie means two
+  /// devices acted within the same millisecond, which is coincidence rather
+  /// than intent.
+  static SyncRecord newer(SyncRecord a, SyncRecord b) {
+    if (b.at != a.at) return b.at > a.at ? b : a;
+    return a.deleted ? a : b;
+  }
+}
+
+/// Timestamps and tombstones for everything syncable, keyed `collection:id`.
+///
+/// Kept beside the collections rather than inside them so the existing stored
+/// shapes are untouched: the library boxes still hold exactly the JSON they
+/// always did, and a build without sync reads them unchanged. It also means a
+/// missing entry is meaningful — it marks data that predates sync, which is
+/// treated as older than anything explicit.
+class SyncMeta {
+  SyncMeta([Map<String, SyncRecord>? records]) : _records = {...?records};
+
+  final Map<String, SyncRecord> _records;
+
+  static String key(String collection, String id) => '$collection:$id';
+
+  Map<String, SyncRecord> get records => Map.unmodifiable(_records);
+  int get length => _records.length;
+
+  SyncRecord? record(String collection, String id) =>
+      _records[key(collection, id)];
+
+  void markAdded(String collection, String id, {int? at}) {
+    _records[key(collection, id)] = SyncRecord.alive(
+      at ?? DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+
+  void markDeleted(String collection, String id, {int? at}) {
+    _records[key(collection, id)] = SyncRecord.tombstone(
+      at ?? DateTime.now().millisecondsSinceEpoch,
+    );
+  }
+
+  /// True when this id should be present after merging.
+  bool isAlive(String collection, String id) =>
+      !(record(collection, id)?.deleted ?? false);
+
+  /// Merge another device's metadata in, newest-per-id winning.
+  void mergeFrom(SyncMeta other) {
+    for (final entry in other._records.entries) {
+      final mine = _records[entry.key];
+      _records[entry.key] = mine == null
+          ? entry.value
+          : SyncRecord.newer(mine, entry.value);
+    }
+  }
+
+  /// Drop tombstones older than [maxAge].
+  ///
+  /// They cannot be kept forever, and they cannot be dropped eagerly either:
+  /// a device that has been offline longer than the window still holds the
+  /// item, sees no tombstone, and re-adds it. The window is the honest
+  /// statement of how long a device may be away and still have its deletions
+  /// respected. Live records are never pruned — they are the collection.
+  int pruneTombstones({
+    Duration maxAge = const Duration(days: 90),
+    DateTime? now,
+  }) {
+    final cutoff =
+        (now ?? DateTime.now()).millisecondsSinceEpoch - maxAge.inMilliseconds;
+    final doomed = [
+      for (final e in _records.entries)
+        if (e.value.deleted && e.value.at < cutoff) e.key,
+    ];
+    for (final k in doomed) {
+      _records.remove(k);
+    }
+    return doomed.length;
+  }
+
+  Map<String, dynamic> toJson() => {
+    for (final e in _records.entries) e.key: e.value.toJson(),
+  };
+
+  static SyncMeta fromJson(Object? raw) {
+    if (raw is! Map) return SyncMeta();
+    final out = <String, SyncRecord>{};
+    raw.forEach((k, v) {
+      final rec = SyncRecord.fromJson(v);
+      if (k is String && rec != null) out[k] = rec;
+    });
+    return SyncMeta(out);
+  }
+}
+
+/// Merge one collection of items across devices.
+///
+/// [local] and [remote] are the item lists as each device holds them; [meta]
+/// is the already-merged metadata. An item survives when its merged record is
+/// not a tombstone, and items with no record at all survive too — that is data
+/// from before sync existed, and dropping it would delete a library to fix a
+/// bookkeeping gap.
+///
+/// Order follows [local] first, so a device's own ordering is preserved and
+/// merging does not reshuffle a list the user is looking at.
+List<FeedItem> mergeItems({
+  required String collection,
+  required List<FeedItem> local,
+  required List<FeedItem> remote,
+  required SyncMeta meta,
+}) {
+  final byId = <String, FeedItem>{};
+  final order = <String>[];
+
+  void take(List<FeedItem> items) {
+    for (final item in items) {
+      if (item.id.isEmpty) continue;
+      if (!byId.containsKey(item.id)) order.add(item.id);
+      // Later writers do not clobber earlier ones: the local copy is at least
+      // as good as the remote and may carry enrichment the other device never
+      // fetched.
+      byId.putIfAbsent(item.id, () => item);
+    }
+  }
+
+  take(local);
+  take(remote);
+
+  return [
+    for (final id in order)
+      if (meta.isAlive(collection, id)) byId[id]!,
+  ];
+}
+
+/// Merge a map keyed by id, newest-per-key winning.
+///
+/// Used for episode progress, where the value is a position rather than an
+/// item, and "newest" genuinely means the furthest-along listen.
+Map<String, int> mergeProgress({
+  required Map<String, int> local,
+  required Map<String, int> remote,
+}) {
+  final out = <String, int>{...local};
+  for (final e in remote.entries) {
+    final mine = out[e.key];
+    // Furthest position wins rather than newest write. Resuming an episode
+    // earlier than you actually reached is the annoying failure; hearing a
+    // few seconds twice is not.
+    if (mine == null || e.value > mine) out[e.key] = e.value;
+  }
+  return out;
+}

--- a/lib/sync/sync_payload.dart
+++ b/lib/sync/sync_payload.dart
@@ -1,0 +1,295 @@
+// The document a device writes into the sync folder.
+//
+// One file per device, named `sunoh-<deviceId>.sync`, holding that device's
+// whole syncable library plus its metadata. Devices never write each other's
+// files, which is what removes the need for locking: a merge reads every file
+// in the folder and writes only its own.
+//
+// Encrypted before it touches the folder — see `SyncBridge` on the native
+// side. The folder is a cloud folder in practice, so the plaintext should
+// never reach it.
+
+import 'dart:convert';
+
+import '../api/dto.dart';
+import '../data/user_playlist.dart';
+import 'sync_merge.dart';
+
+/// Bumped only for a change old readers cannot cope with. A device running an
+/// older build must be able to skip a file it does not understand rather than
+/// import half of it.
+const int kSyncFormatVersion = 1;
+
+/// Everything one device contributes to the merge.
+class SyncPayload {
+  const SyncPayload({
+    required this.deviceId,
+    required this.writtenAt,
+    required this.meta,
+    this.liked = const [],
+    this.savedAlbums = const [],
+    this.savedPlaylists = const [],
+    this.savedArtists = const [],
+    this.userPlaylists = const [],
+    this.podcasts = const [],
+    this.episodeProgress = const {},
+    this.settings = const {},
+    this.settingsAt = 0,
+  });
+
+  final String deviceId;
+  final int writtenAt;
+  final SyncMeta meta;
+
+  final List<FeedItem> liked;
+  final List<FeedItem> savedAlbums;
+  final List<FeedItem> savedPlaylists;
+  final List<FeedItem> savedArtists;
+  final List<UserPlaylist> userPlaylists;
+  final List<FeedItem> podcasts;
+  final Map<String, int> episodeProgress;
+
+  /// Settings sync as one blob with a single timestamp rather than per key.
+  ///
+  /// Per-key merging needs a timestamp per key and a migration to add them,
+  /// for a conflict that barely arises: two devices rarely change different
+  /// settings between syncs, and when they do, losing one is a shrug. Whole
+  /// set, last writer wins.
+  final Map<String, dynamic> settings;
+  final int settingsAt;
+
+  /// Deliberately excluded, and worth stating so it is a decision rather than
+  /// an oversight:
+  ///
+  /// - **Downloads.** The entries hold absolute file paths that mean nothing
+  ///   on another device, and the audio itself is far too large to sync. A
+  ///   future version could sync the *intent* to have something offline and
+  ///   let each device fetch its own copy.
+  /// - **Playback queue and position.** Per-device state. Syncing it makes two
+  ///   phones fight over what is playing.
+  /// - **History.** Merges as a plain union elsewhere; it needs no tombstones
+  ///   because nothing is ever explicitly removed from it.
+  static const excluded = ['downloads', 'playback queue', 'history'];
+
+  Map<String, dynamic> toJson() => {
+    'v': kSyncFormatVersion,
+    'device': deviceId,
+    'at': writtenAt,
+    'meta': meta.toJson(),
+    'liked': [for (final s in liked) s.toJson()],
+    'albums': [for (final s in savedAlbums) s.toJson()],
+    'playlists': [for (final s in savedPlaylists) s.toJson()],
+    'artists': [for (final s in savedArtists) s.toJson()],
+    'uplaylists': [for (final p in userPlaylists) p.toJson()],
+    'podcasts': [for (final s in podcasts) s.toJson()],
+    'progress': episodeProgress,
+    'settings': settings,
+    'settingsAt': settingsAt,
+  };
+
+  List<int> encode() => utf8.encode(jsonEncode(toJson()));
+
+  /// Parse a file from the folder.
+  ///
+  /// Returns null for anything unreadable rather than throwing: these bytes
+  /// came out of a directory the user controls and a cloud client writes to,
+  /// so truncated files, partial uploads and unrelated documents are normal
+  /// rather than exceptional. One bad file must not fail the whole sync.
+  static SyncPayload? decode(List<int> bytes) {
+    try {
+      final raw = jsonDecode(utf8.decode(bytes));
+      if (raw is! Map) return null;
+      final version = (raw['v'] as num?)?.toInt() ?? 0;
+      // A newer device wrote something this build cannot read. Skipping is
+      // right: importing half of an unknown shape is worse than ignoring it.
+      if (version > kSyncFormatVersion) return null;
+      final device = raw['device']?.toString();
+      if (device == null || device.isEmpty) return null;
+
+      return SyncPayload(
+        deviceId: device,
+        writtenAt: (raw['at'] as num?)?.toInt() ?? 0,
+        meta: SyncMeta.fromJson(raw['meta']),
+        liked: _items(raw['liked']),
+        savedAlbums: _items(raw['albums']),
+        savedPlaylists: _items(raw['playlists']),
+        savedArtists: _items(raw['artists']),
+        userPlaylists: _playlists(raw['uplaylists']),
+        podcasts: _items(raw['podcasts']),
+        episodeProgress: _progress(raw['progress']),
+        settings: raw['settings'] is Map
+            ? (raw['settings'] as Map).cast<String, dynamic>()
+            : const {},
+        settingsAt: (raw['settingsAt'] as num?)?.toInt() ?? 0,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static List<FeedItem> _items(Object? raw) {
+    if (raw is! List) return const [];
+    final out = <FeedItem>[];
+    for (final e in raw) {
+      if (e is! Map) continue;
+      try {
+        out.add(FeedItem.fromJson(e.cast<String, dynamic>()));
+      } catch (_) {
+        // One malformed entry should not cost the whole collection.
+      }
+    }
+    return out;
+  }
+
+  static List<UserPlaylist> _playlists(Object? raw) {
+    if (raw is! List) return const [];
+    final out = <UserPlaylist>[];
+    for (final e in raw) {
+      if (e is! Map) continue;
+      try {
+        out.add(UserPlaylist.fromJson(e.cast<String, dynamic>()));
+      } catch (_) {
+        // Same.
+      }
+    }
+    return out;
+  }
+
+  static Map<String, int> _progress(Object? raw) {
+    if (raw is! Map) return const {};
+    final out = <String, int>{};
+    raw.forEach((k, v) {
+      final secs = (v as num?)?.toInt();
+      if (k is String && secs != null && secs > 0) out[k] = secs;
+    });
+    return out;
+  }
+}
+
+/// The result of folding every file in the folder together.
+class MergedLibrary {
+  const MergedLibrary({
+    required this.meta,
+    required this.liked,
+    required this.savedAlbums,
+    required this.savedPlaylists,
+    required this.savedArtists,
+    required this.userPlaylists,
+    required this.podcasts,
+    required this.episodeProgress,
+    required this.settings,
+    required this.settingsAt,
+  });
+
+  final SyncMeta meta;
+  final List<FeedItem> liked;
+  final List<FeedItem> savedAlbums;
+  final List<FeedItem> savedPlaylists;
+  final List<FeedItem> savedArtists;
+  final List<UserPlaylist> userPlaylists;
+  final List<FeedItem> podcasts;
+  final Map<String, int> episodeProgress;
+  final Map<String, dynamic> settings;
+  final int settingsAt;
+}
+
+/// Fold this device's payload together with every other device's.
+///
+/// Metadata merges first and completely, because the item merge reads it to
+/// decide what survives. Doing it per collection as you go would let a
+/// tombstone from a file read later fail to suppress an item already kept.
+MergedLibrary mergeAll({
+  required SyncPayload local,
+  required List<SyncPayload> remotes,
+}) {
+  final meta = SyncMeta(local.meta.records);
+  for (final r in remotes) {
+    meta.mergeFrom(r.meta);
+  }
+
+  List<FeedItem> fold(
+    String collection,
+    List<FeedItem> Function(SyncPayload) pick,
+  ) {
+    var acc = pick(local);
+    for (final r in remotes) {
+      acc = mergeItems(
+        collection: collection,
+        local: acc,
+        remote: pick(r),
+        meta: meta,
+      );
+    }
+    // A single-device folder still needs the tombstone filter applied.
+    return mergeItems(
+      collection: collection,
+      local: acc,
+      remote: const [],
+      meta: meta,
+    );
+  }
+
+  var progress = local.episodeProgress;
+  for (final r in remotes) {
+    progress = mergeProgress(local: progress, remote: r.episodeProgress);
+  }
+
+  // Settings: newest write for the whole set.
+  var settings = local.settings;
+  var settingsAt = local.settingsAt;
+  for (final r in remotes) {
+    if (r.settingsAt > settingsAt) {
+      settings = r.settings;
+      settingsAt = r.settingsAt;
+    }
+  }
+
+  return MergedLibrary(
+    meta: meta,
+    liked: fold('liked', (p) => p.liked),
+    savedAlbums: fold('album', (p) => p.savedAlbums),
+    savedPlaylists: fold('playlist', (p) => p.savedPlaylists),
+    savedArtists: fold('artist', (p) => p.savedArtists),
+    userPlaylists: _mergePlaylists(local, remotes, meta),
+    podcasts: fold('podcast', (p) => p.podcasts),
+    episodeProgress: progress,
+    settings: settings,
+    settingsAt: settingsAt,
+  );
+}
+
+/// User playlists merge per playlist on `updatedAt`, not per song.
+///
+/// Per-song merging inside a playlist would need a record per song per
+/// playlist, and would still not know what to do about order. Editing the same
+/// playlist on two devices between syncs is rare; losing the older of the two
+/// edits is understandable, where a silently interleaved track order is not.
+List<UserPlaylist> _mergePlaylists(
+  SyncPayload local,
+  List<SyncPayload> remotes,
+  SyncMeta meta,
+) {
+  final byId = <String, UserPlaylist>{};
+  final order = <String>[];
+
+  void take(List<UserPlaylist> playlists) {
+    for (final p in playlists) {
+      if (p.id.isEmpty) continue;
+      if (!byId.containsKey(p.id)) order.add(p.id);
+      final mine = byId[p.id];
+      if (mine == null || p.updatedAt.isAfter(mine.updatedAt)) {
+        byId[p.id] = p;
+      }
+    }
+  }
+
+  take(local.userPlaylists);
+  for (final r in remotes) {
+    take(r.userPlaylists);
+  }
+
+  return [
+    for (final id in order)
+      if (meta.isAlive('uplaylist', id)) byId[id]!,
+  ];
+}

--- a/lib/sync/sync_service.dart
+++ b/lib/sync/sync_service.dart
@@ -22,7 +22,6 @@ import 'package:flutter/foundation.dart';
 import '../audio/library_store.dart';
 import '../audio/settings_store.dart';
 import 'sync_channel.dart';
-import 'sync_merge.dart';
 import 'sync_payload.dart';
 
 enum SyncStatus { off, idle, syncing, ok, noAccess, failed }

--- a/lib/sync/sync_service.dart
+++ b/lib/sync/sync_service.dart
@@ -1,0 +1,299 @@
+// Orchestrates one sync: read every device's file, merge, write ours back.
+//
+// The order matters and is the whole of the logic:
+//
+//   1. Read every `.sync` file in the folder that decrypts with our key.
+//   2. Merge them with our own library. Metadata first, then collections,
+//      because the collection merge reads the metadata to decide what lives.
+//   3. Apply the merged result locally.
+//   4. Write our file back, now carrying the merged state.
+//
+// Step 4 is what propagates another device's changes onward: after A and B
+// have both synced, each file holds the union, so a third device joining later
+// gets everything from whichever file it reads.
+//
+// Nothing here talks to the network. The folder is a directory the user picked
+// with the system picker; whatever syncs it does the moving.
+
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+
+import '../audio/library_store.dart';
+import '../audio/settings_store.dart';
+import 'sync_channel.dart';
+import 'sync_merge.dart';
+import 'sync_payload.dart';
+
+enum SyncStatus { off, idle, syncing, ok, noAccess, failed }
+
+class SyncResult {
+  const SyncResult({required this.status, this.filesRead = 0, this.message});
+  final SyncStatus status;
+  final int filesRead;
+  final String? message;
+}
+
+class SyncService extends ChangeNotifier {
+  SyncService({
+    required this.library,
+    required this.settings,
+    SyncChannel? channel,
+  }) : _channel = channel ?? SyncChannel.instance;
+
+  final LibraryStore library;
+  final SettingsStore settings;
+  final SyncChannel _channel;
+
+  SyncStatus _status = SyncStatus.off;
+  SyncStatus get status => _status;
+
+  DateTime? _lastSync;
+  DateTime? get lastSync => _lastSync;
+
+  String? _folderName;
+  String? get folderName => _folderName;
+
+  bool get isConfigured => _tree != null && _key != null;
+
+  String? _tree;
+  String? _key;
+  String? _deviceId;
+
+  /// This device's file name. Derived from the device id so two devices never
+  /// write the same file, which is what removes the need for locking.
+  String get fileName => 'sunoh-${_deviceId ?? 'unknown'}.sync';
+
+  /// Load saved configuration. Safe to call repeatedly.
+  Future<void> restore() async {
+    final saved = await settings.loadSync();
+    _tree = saved.treeUri;
+    _key = saved.key;
+    _deviceId = saved.deviceId;
+    _lastSync = saved.lastSyncAt == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(saved.lastSyncAt!);
+    if (isConfigured) {
+      _folderName = await _channel.folderName(_tree!);
+      _status = SyncStatus.idle;
+    } else {
+      _status = SyncStatus.off;
+    }
+    notifyListeners();
+  }
+
+  /// Pick a folder and generate a key if this device does not have one.
+  ///
+  /// Returns the recovery code to show the user, or null if they cancelled.
+  /// The code is shown once and stored; the second device is set up by
+  /// entering it rather than generating its own, since two different keys mean
+  /// two devices writing files neither can read.
+  Future<String?> setUp() async {
+    final tree = await _channel.pickFolder();
+    if (tree == null) return null;
+    final key = _key ?? await _channel.generateKey();
+    if (key == null) return null;
+
+    _tree = tree;
+    _key = key;
+    _deviceId ??= _newDeviceId();
+    _folderName = await _channel.folderName(tree);
+    await _persist();
+    _status = SyncStatus.idle;
+    notifyListeners();
+    return key;
+  }
+
+  /// Join an existing setup with a code from the first device.
+  Future<bool> joinWithCode(String code) async {
+    final trimmed = code.trim();
+    if (trimmed.isEmpty) return false;
+    final tree = await _channel.pickFolder();
+    if (tree == null) return false;
+
+    _tree = tree;
+    _key = trimmed;
+    _deviceId ??= _newDeviceId();
+    _folderName = await _channel.folderName(tree);
+    await _persist();
+    _status = SyncStatus.idle;
+    notifyListeners();
+
+    // Prove the code before claiming success: a wrong one decrypts nothing,
+    // and telling the user later — after their library silently fails to
+    // arrive — is much worse than telling them now.
+    final result = await syncNow();
+    if (result.status == SyncStatus.ok && result.filesRead == 0) {
+      // An empty folder is legitimate for the very first device, so this is
+      // not treated as a failure. It is reported so the UI can say so.
+      debugPrint('[sync] joined, but no readable files yet');
+    }
+    return result.status == SyncStatus.ok;
+  }
+
+  Future<void> disable({bool removeFile = true}) async {
+    if (removeFile && _tree != null) {
+      await _channel.delete(treeUri: _tree!, name: fileName);
+    }
+    _tree = null;
+    _key = null;
+    _folderName = null;
+    _status = SyncStatus.off;
+    await settings.saveSync(treeUri: '', key: '', deviceId: _deviceId ?? '');
+    notifyListeners();
+  }
+
+  /// Read, merge, apply, write.
+  Future<SyncResult> syncNow() async {
+    if (!isConfigured) return const SyncResult(status: SyncStatus.off);
+    if (_status == SyncStatus.syncing) {
+      return const SyncResult(status: SyncStatus.syncing);
+    }
+
+    _status = SyncStatus.syncing;
+    notifyListeners();
+
+    try {
+      if (!await _channel.hasAccess(_tree!)) {
+        // The grant can be revoked from system settings, or the volume can go
+        // away. Neither is an error worth a stack trace; it is a state the UI
+        // has to be able to describe and offer to fix.
+        _status = SyncStatus.noAccess;
+        notifyListeners();
+        return const SyncResult(status: SyncStatus.noAccess);
+      }
+
+      final local = await _buildPayload();
+      final files = await _channel.readAll(treeUri: _tree!, key: _key!);
+
+      final remotes = <SyncPayload>[];
+      for (final entry in files.entries) {
+        // Skip our own file: its contents are what we are about to replace,
+        // and re-merging them costs work for no information.
+        if (entry.key == fileName) continue;
+        final parsed = SyncPayload.decode(entry.value);
+        if (parsed != null) remotes.add(parsed);
+      }
+
+      final merged = mergeAll(local: local, remotes: remotes);
+      await _apply(merged);
+
+      final outgoing = SyncPayload(
+        deviceId: _deviceId!,
+        writtenAt: DateTime.now().millisecondsSinceEpoch,
+        meta: merged.meta,
+        liked: merged.liked,
+        savedAlbums: merged.savedAlbums,
+        savedPlaylists: merged.savedPlaylists,
+        savedArtists: merged.savedArtists,
+        userPlaylists: merged.userPlaylists,
+        podcasts: merged.podcasts,
+        episodeProgress: merged.episodeProgress,
+        settings: merged.settings,
+        settingsAt: merged.settingsAt,
+      );
+
+      final wrote = await _channel.write(
+        treeUri: _tree!,
+        name: fileName,
+        key: _key!,
+        bytes: Uint8List.fromList(outgoing.encode()),
+      );
+
+      _lastSync = DateTime.now();
+      await _persist();
+      _status = wrote ? SyncStatus.ok : SyncStatus.failed;
+      notifyListeners();
+      debugPrint(
+        '[sync] merged ${remotes.length} remote file(s), '
+        'liked=${merged.liked.length} playlists=${merged.userPlaylists.length} '
+        'wrote=$wrote',
+      );
+      return SyncResult(
+        status: _status,
+        filesRead: remotes.length,
+        message: wrote ? null : 'could not write to the folder',
+      );
+    } catch (e, st) {
+      debugPrint('[sync] failed: $e\n$st');
+      _status = SyncStatus.failed;
+      notifyListeners();
+      return SyncResult(status: SyncStatus.failed, message: '$e');
+    }
+  }
+
+  Future<SyncPayload> _buildPayload() async {
+    final meta = await library.loadSyncMeta();
+    // Prune here rather than on write: this is the one place that runs on a
+    // schedule, and an unbounded tombstone map is the slow leak of any
+    // sync design.
+    meta.pruneTombstones();
+
+    final saved = await settings.loadSyncableSettings();
+    return SyncPayload(
+      deviceId: _deviceId!,
+      writtenAt: DateTime.now().millisecondsSinceEpoch,
+      meta: meta,
+      liked: await library.loadLikedSongs(),
+      savedAlbums: await library.loadSaved('album'),
+      savedPlaylists: await library.loadSaved('playlist'),
+      savedArtists: await library.loadSaved('artist'),
+      userPlaylists: await library.loadUserPlaylists(),
+      podcasts: await library.loadSubscribedPodcasts(),
+      episodeProgress: await library.loadEpisodeProgress(),
+      settings: saved.values,
+      settingsAt: saved.updatedAt,
+    );
+  }
+
+  Future<void> _apply(MergedLibrary merged) async {
+    await library.replaceLiked(merged.liked);
+    await library.replaceSaved('album', merged.savedAlbums);
+    await library.replaceSaved('playlist', merged.savedPlaylists);
+    await library.replaceSaved('artist', merged.savedArtists);
+    await library.replaceUserPlaylists(merged.userPlaylists);
+    await library.replaceSubscribedPodcasts(merged.podcasts);
+    await library.replaceEpisodeProgress(merged.episodeProgress);
+    await library.saveSyncMeta(merged.meta);
+    if (merged.settings.isNotEmpty) {
+      await settings.applySyncableSettings(merged.settings, merged.settingsAt);
+    }
+  }
+
+  Future<void> _persist() => settings.saveSync(
+    treeUri: _tree ?? '',
+    key: _key ?? '',
+    deviceId: _deviceId ?? '',
+    lastSyncAt: _lastSync?.millisecondsSinceEpoch,
+  );
+
+  /// Random enough that two devices will not collide, short enough to read in
+  /// a filename. Not a fingerprint: it identifies a file, not a person, and it
+  /// is regenerated if sync is set up again from scratch.
+  static String _newDeviceId() {
+    const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+    final now = DateTime.now().microsecondsSinceEpoch;
+    var n = now;
+    final out = StringBuffer();
+    for (var i = 0; i < 8; i++) {
+      out.write(alphabet[n % alphabet.length]);
+      n ~/= alphabet.length;
+    }
+    return out.toString();
+  }
+}
+
+/// Encode/decode helper kept here so the payload stays free of dart:convert
+/// concerns at its call sites.
+String prettyCode(String key) => key;
+
+/// Decode a base64 key defensively — used when the user types a code in.
+bool looksLikeKey(String code) {
+  final trimmed = code.trim();
+  if (trimmed.length < 20) return false;
+  try {
+    return base64Decode(trimmed).length == 16;
+  } catch (_) {
+    return false;
+  }
+}

--- a/test/local_media_test.dart
+++ b/test/local_media_test.dart
@@ -255,9 +255,8 @@ void main() {
       expect(scan.folders.first.name, 'Music');
     });
 
-    test('choosing nothing uses the whole device', () async {
-      // The default. A fresh install has to find music without being
-      // configured first, so an empty choice cannot mean an empty library.
+    test('the default takes the whole device', () async {
+      // A fresh install has to find music without being configured first.
       stub([
         _row(id: '1', path: '/Music/a.mp3'),
         _row(id: '2', path: '/WhatsApp/voice.mp3'),
@@ -267,49 +266,65 @@ void main() {
       expect(scan.songs.map((s) => s.id), ['1', '2']);
     });
 
-    test('choosing a folder leaves everything else out', () async {
+    test('turning one folder off leaves the rest alone', () async {
       stub([
         _row(id: '1', path: '/Music/a.mp3'),
         _row(id: '2', path: '/WhatsApp/voice.mp3'),
       ]);
       final scan = await LocalMediaChannel.instance.scan(
-        includedFolders: {'/Music'},
+        rules: const FolderRules(overrides: {'/WhatsApp': false}),
       );
 
       expect(scan.songs.map((s) => s.id), ['1']);
     });
 
-    test('a chosen folder brings its subfolders with it', () async {
-      // The reason this is an include list and not an exclude list: one
-      // album-per-folder library is a hundred directories under one parent.
+    test('taking only one folder is the default plus one rule', () async {
       stub([
         _row(id: '1', path: '/Music/Rock/Album/a.mp3'),
-        _row(id: '2', path: '/Music/b.mp3'),
-        _row(id: '3', path: '/Podcasts/c.mp3'),
+        _row(id: '2', path: '/Podcasts/c.mp3'),
       ]);
       final scan = await LocalMediaChannel.instance.scan(
-        includedFolders: {'/Music'},
+        rules: const FolderRules(
+          defaultIncluded: false,
+          overrides: {'/Music': true},
+        ),
       );
 
-      expect(scan.songs.map((s) => s.id), ['1', '2']);
+      expect(scan.songs.map((s) => s.id), ['1'], reason: 'subfolders included');
+    });
+
+    test('a folder inside a chosen one can still be dropped', () async {
+      // The case an include-only list cannot express.
+      stub([
+        _row(id: '1', path: '/Music/Rock/a.mp3'),
+        _row(id: '2', path: '/Music/Voice Memos/b.mp3'),
+      ]);
+      final scan = await LocalMediaChannel.instance.scan(
+        rules: const FolderRules(
+          defaultIncluded: false,
+          overrides: {'/Music': true, '/Music/Voice Memos': false},
+        ),
+      );
+
+      expect(scan.songs.map((s) => s.id), ['1']);
     });
 
     test('a folder left out still appears in the folder list', () async {
-      // Otherwise there is no way back: the folder you left out would vanish
-      // from the list that lets you add it.
+      // Otherwise there is no way back: the folder you turned off would vanish
+      // from the list that lets you turn it on.
       stub([
         _row(id: '1', path: '/Music/a.mp3'),
         _row(id: '2', path: '/WhatsApp/voice.mp3'),
       ]);
       final scan = await LocalMediaChannel.instance.scan(
-        includedFolders: {'/Music'},
+        rules: const FolderRules(overrides: {'/WhatsApp': false}),
       );
 
       expect(scan.folders.map((f) => f.path), contains('/WhatsApp'));
       expect(
         scan.folders.firstWhere((f) => f.path == '/WhatsApp').trackCount,
         1,
-        reason: 'counts cover every row, chosen or not',
+        reason: 'counts cover every row, taken or not',
       );
     });
 
@@ -331,7 +346,7 @@ void main() {
         ),
       ]);
       final scan = await LocalMediaChannel.instance.scan(
-        includedFolders: {'/Music'},
+        rules: const FolderRules(overrides: {'/Tones': false}),
       );
 
       expect(scan.albums.map((a) => a.name), ['Real']);
@@ -345,10 +360,10 @@ void main() {
         _row(id: '2', path: '/MusicVideos/b.mp3'),
       ]);
       final scan = await LocalMediaChannel.instance.scan(
-        includedFolders: {'/Music'},
+        rules: const FolderRules(overrides: {'/Music': false}),
       );
 
-      expect(scan.songs.map((s) => s.id), ['1']);
+      expect(scan.songs.map((s) => s.id), ['2']);
     });
 
     test('a path with no directory part is not counted as a folder', () async {
@@ -360,28 +375,145 @@ void main() {
     });
   });
 
-  group('isUnderAnyRoot', () {
-    test('no roots means everything', () {
-      expect(isUnderAnyRoot('/anywhere', const {}), isTrue);
+  group('FolderRules resolution', () {
+    test('no rules means everything', () {
+      expect(const FolderRules().allows('/anywhere'), isTrue);
+      expect(const FolderRules().isDefault, isTrue);
     });
 
-    test('the root itself counts', () {
-      expect(isUnderAnyRoot('/Music', const {'/Music'}), isTrue);
-    });
-
-    test('a descendant counts at any depth', () {
-      expect(isUnderAnyRoot('/Music/a/b/c', const {'/Music'}), isTrue);
-    });
-
-    test('a prefix that is not a path boundary does not count', () {
-      expect(isUnderAnyRoot('/MusicVideos', const {'/Music'}), isFalse);
-    });
-
-    test('any one root is enough', () {
-      expect(
-        isUnderAnyRoot('/Podcasts/x', const {'/Music', '/Podcasts'}),
-        isTrue,
+    test('the nearest rule up the path wins', () {
+      const rules = FolderRules(
+        defaultIncluded: false,
+        overrides: {'/a': true, '/a/b': false, '/a/b/c': true},
       );
+      expect(rules.allows('/a/x'), isTrue);
+      expect(rules.allows('/a/b/x'), isFalse);
+      expect(rules.allows('/a/b/c/x'), isTrue);
+      expect(rules.allows('/other'), isFalse);
+    });
+
+    test('a folder with no rule anywhere above it follows the default', () {
+      // The reason the default is a visible row: a folder created tomorrow has
+      // no rule, and has to behave like the ones around it rather than vanish.
+      const rules = FolderRules(overrides: {'/a': false});
+      expect(rules.allows('/brand/new'), isTrue);
+    });
+
+    test('a prefix that is not a path boundary is a different folder', () {
+      const rules = FolderRules(overrides: {'/Music': false});
+      expect(rules.allows('/MusicVideos'), isTrue);
+    });
+  });
+
+  group('FolderRules editing', () {
+    test('a rule matching what it inherits is not stored', () {
+      // Otherwise the rule set grows with entries that change nothing and
+      // stop tracking the folder above them.
+      final rules = const FolderRules().set('/a', included: true);
+      expect(rules.overrides, isEmpty);
+      expect(rules.isDefault, isTrue);
+    });
+
+    test('a rule that says nothing today is kept for when it does', () {
+      // '/a/b' is redundant while '/a' is off. It is the only thing keeping
+      // that folder out the moment '/a' goes back on, and dropping it would
+      // resurrect the music far away from the tap that caused it.
+      const before = FolderRules(overrides: {'/a/b': false});
+      final off = before.set('/a', included: false);
+      expect(off.allows('/a/b'), isFalse);
+
+      final backOn = off.set('/a', included: true);
+      expect(backOn.allows('/a'), isTrue);
+      expect(backOn.allows('/a/b'), isFalse, reason: 'still out');
+    });
+
+    test('a rule survives the default going off and on again', () {
+      const before = FolderRules(overrides: {'/a': false});
+      final round = before
+          .withDefault(included: false)
+          .withDefault(included: true);
+
+      expect(round.allows('/a'), isFalse);
+    });
+
+    test('a contradicting rule underneath survives', () {
+      // Someone deliberately took '/a/b' out. Re-ticking the tree above it is
+      // not a request to undo that.
+      const before = FolderRules(
+        defaultIncluded: false,
+        overrides: {'/a/b': false},
+      );
+      final after = before.set('/a', included: true);
+
+      expect(after.allows('/a'), isTrue);
+      expect(after.allows('/a/b'), isFalse);
+    });
+
+    test('flipping the default keeps every rule', () {
+      const before = FolderRules(overrides: {'/a': false, '/b': true});
+      final after = before.withDefault(included: false);
+
+      expect(after.defaultIncluded, isFalse);
+      expect(after.overrides.keys, unorderedEquals(['/a', '/b']));
+      expect(after.allows('/b'), isTrue, reason: 'still the one folder in');
+    });
+
+    test('a rule survives a default flip when a folder sits between', () {
+      // Caught on a real device: with the tree ticked on and one album inside
+      // it ticked off, turning the device row off dropped the album's rule,
+      // because it happened to match the new default.
+      const before = FolderRules(
+        overrides: {'/lib': true, '/lib/voice notes': false},
+      );
+      final after = before.withDefault(included: false);
+
+      expect(after.allows('/lib/a'), isTrue);
+      expect(
+        after.allows('/lib/voice notes'),
+        isFalse,
+        reason: 'the album stays out of the tree it was taken out of',
+      );
+    });
+
+    test('a rule under a contradicting parent survives a set', () {
+      // Same shape, reached by setting a folder rather than the default.
+      const before = FolderRules(
+        defaultIncluded: false,
+        overrides: {'/lib': true, '/lib/voice notes': false},
+      );
+      final after = before.set('/lib', included: true);
+
+      expect(after.allows('/lib/voice notes'), isFalse);
+    });
+
+    test('turning a folder off then on again leaves no trace', () {
+      final rules = const FolderRules()
+          .set('/a', included: false)
+          .set('/a', included: true);
+      expect(rules.isDefault, isTrue);
+    });
+  });
+
+  group('FolderRules storage', () {
+    test('a round trip keeps the default and every rule', () {
+      const rules = FolderRules(
+        defaultIncluded: false,
+        overrides: {'/a': true, '/a/b': false},
+      );
+      expect(FolderRules.decode(rules.encode()).sameAs(rules), isTrue);
+    });
+
+    test('an empty or unreadable value falls back to taking everything', () {
+      // A half-written setting must not empty the library.
+      expect(FolderRules.decode(const []).isDefault, isTrue);
+      expect(FolderRules.decode(const ['nonsense', '+']).isDefault, isTrue);
+    });
+
+    test('sameAs sees a differing rule', () {
+      const a = FolderRules(overrides: {'/x': false});
+      expect(a.sameAs(const FolderRules(overrides: {'/x': true})), isFalse);
+      expect(a.sameAs(const FolderRules()), isFalse);
+      expect(a.sameAs(const FolderRules(overrides: {'/x': false})), isTrue);
     });
   });
 

--- a/test/local_media_test.dart
+++ b/test/local_media_test.dart
@@ -241,6 +241,178 @@ void main() {
     });
   });
 
+  group('folders', () {
+    test('every folder is reported with a count, largest first', () async {
+      stub([
+        _row(id: '1', path: '/Music/a.mp3'),
+        _row(id: '2', path: '/Music/b.mp3'),
+        _row(id: '3', path: '/Ringtones/r.mp3'),
+      ]);
+      final scan = await LocalMediaChannel.instance.scan();
+
+      expect(scan.folders.map((f) => f.path), ['/Music', '/Ringtones']);
+      expect(scan.folders.first.trackCount, 2);
+      expect(scan.folders.first.name, 'Music');
+    });
+
+    test('choosing nothing uses the whole device', () async {
+      // The default. A fresh install has to find music without being
+      // configured first, so an empty choice cannot mean an empty library.
+      stub([
+        _row(id: '1', path: '/Music/a.mp3'),
+        _row(id: '2', path: '/WhatsApp/voice.mp3'),
+      ]);
+      final scan = await LocalMediaChannel.instance.scan();
+
+      expect(scan.songs.map((s) => s.id), ['1', '2']);
+    });
+
+    test('choosing a folder leaves everything else out', () async {
+      stub([
+        _row(id: '1', path: '/Music/a.mp3'),
+        _row(id: '2', path: '/WhatsApp/voice.mp3'),
+      ]);
+      final scan = await LocalMediaChannel.instance.scan(
+        includedFolders: {'/Music'},
+      );
+
+      expect(scan.songs.map((s) => s.id), ['1']);
+    });
+
+    test('a chosen folder brings its subfolders with it', () async {
+      // The reason this is an include list and not an exclude list: one
+      // album-per-folder library is a hundred directories under one parent.
+      stub([
+        _row(id: '1', path: '/Music/Rock/Album/a.mp3'),
+        _row(id: '2', path: '/Music/b.mp3'),
+        _row(id: '3', path: '/Podcasts/c.mp3'),
+      ]);
+      final scan = await LocalMediaChannel.instance.scan(
+        includedFolders: {'/Music'},
+      );
+
+      expect(scan.songs.map((s) => s.id), ['1', '2']);
+    });
+
+    test('a folder left out still appears in the folder list', () async {
+      // Otherwise there is no way back: the folder you left out would vanish
+      // from the list that lets you add it.
+      stub([
+        _row(id: '1', path: '/Music/a.mp3'),
+        _row(id: '2', path: '/WhatsApp/voice.mp3'),
+      ]);
+      final scan = await LocalMediaChannel.instance.scan(
+        includedFolders: {'/Music'},
+      );
+
+      expect(scan.folders.map((f) => f.path), contains('/WhatsApp'));
+      expect(
+        scan.folders.firstWhere((f) => f.path == '/WhatsApp').trackCount,
+        1,
+        reason: 'counts cover every row, chosen or not',
+      );
+    });
+
+    test('leaving a folder out removes its albums and artists too', () async {
+      stub([
+        _row(
+          id: '1',
+          path: '/Music/a.mp3',
+          album: 'Real',
+          artist: 'A',
+          albumId: '1',
+        ),
+        _row(
+          id: '2',
+          path: '/Tones/t.mp3',
+          album: 'Tones',
+          artist: 'System',
+          albumId: '2',
+        ),
+      ]);
+      final scan = await LocalMediaChannel.instance.scan(
+        includedFolders: {'/Music'},
+      );
+
+      expect(scan.albums.map((a) => a.name), ['Real']);
+      expect(scan.artists.map((a) => a.name), ['A']);
+    });
+
+    test('a sibling with the same prefix is not swept in', () async {
+      // '/Music' must not silently take '/MusicVideos' with it.
+      stub([
+        _row(id: '1', path: '/Music/a.mp3'),
+        _row(id: '2', path: '/MusicVideos/b.mp3'),
+      ]);
+      final scan = await LocalMediaChannel.instance.scan(
+        includedFolders: {'/Music'},
+      );
+
+      expect(scan.songs.map((s) => s.id), ['1']);
+    });
+
+    test('a path with no directory part is not counted as a folder', () async {
+      stub([_row(id: '1', path: 'bare.mp3')]);
+      final scan = await LocalMediaChannel.instance.scan();
+
+      expect(scan.songs, hasLength(1), reason: 'still playable');
+      expect(scan.folders, isEmpty);
+    });
+  });
+
+  group('isUnderAnyRoot', () {
+    test('no roots means everything', () {
+      expect(isUnderAnyRoot('/anywhere', const {}), isTrue);
+    });
+
+    test('the root itself counts', () {
+      expect(isUnderAnyRoot('/Music', const {'/Music'}), isTrue);
+    });
+
+    test('a descendant counts at any depth', () {
+      expect(isUnderAnyRoot('/Music/a/b/c', const {'/Music'}), isTrue);
+    });
+
+    test('a prefix that is not a path boundary does not count', () {
+      expect(isUnderAnyRoot('/MusicVideos', const {'/Music'}), isFalse);
+    });
+
+    test('any one root is enough', () {
+      expect(
+        isUnderAnyRoot('/Podcasts/x', const {'/Music', '/Podcasts'}),
+        isTrue,
+      );
+    });
+  });
+
+  group('folderLocation', () {
+    test('drops the storage prefix and the folder name itself', () {
+      expect(
+        folderLocation('/storage/emulated/0/Download/Seal/Tere Naam'),
+        'Download/Seal',
+      );
+    });
+
+    test('two same-named folders read differently', () {
+      // The whole reason the subtitle exists.
+      expect(
+        folderLocation('/storage/emulated/0/Download/Seal/Tere Naam'),
+        isNot(folderLocation('/storage/emulated/0/Music/Tere Naam')),
+      );
+    });
+
+    test('a folder at the storage root says where it is', () {
+      expect(folderLocation('/storage/emulated/0/Music'), 'Internal storage');
+    });
+
+    test('a removable volume keeps its path', () {
+      expect(
+        folderLocation('/storage/1A2B-3C4D/Music/Rock'),
+        'storage/1A2B-3C4D/Music',
+      );
+    });
+  });
+
   group('failure', () {
     test('a platform error yields an empty scan, not a throw', () async {
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger

--- a/test/sync_merge_test.dart
+++ b/test/sync_merge_test.dart
@@ -1,0 +1,224 @@
+// Tests for the sync merge rules.
+//
+// This is the part of sync that can lose data, so it is tested hardest. Every
+// case here is one a two-phone setup actually produces: unliking on one device,
+// editing both while offline, a device that has been away for months, and a
+// library that predates sync entirely.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sunoh/api/dto.dart';
+import 'package:sunoh/sync/sync_merge.dart';
+
+FeedItem _song(String id) =>
+    FeedItem(id: id, title: 'Song $id', type: 'song', image: const []);
+
+const _liked = 'liked';
+
+void main() {
+  group('tombstones', () {
+    test('an unlike on one device is not undone by the other', () {
+      // The failure the whole design exists to prevent. Phone A unlikes 'b';
+      // phone B still has it. A plain union puts it back on both.
+      final meta = SyncMeta()
+        ..markAdded(_liked, 'a', at: 100)
+        ..markAdded(_liked, 'b', at: 100)
+        ..markDeleted(_liked, 'b', at: 200);
+
+      final merged = mergeItems(
+        collection: _liked,
+        local: [_song('a')],
+        remote: [_song('a'), _song('b')],
+        meta: meta,
+      );
+
+      expect(merged.map((s) => s.id), ['a']);
+    });
+
+    test('re-liking after a delete wins, because it is newer', () {
+      final meta = SyncMeta()
+        ..markDeleted(_liked, 'b', at: 200)
+        ..markAdded(_liked, 'b', at: 300);
+
+      final merged = mergeItems(
+        collection: _liked,
+        local: const [],
+        remote: [_song('b')],
+        meta: meta,
+      );
+
+      expect(merged.map((s) => s.id), ['b']);
+    });
+
+    test('a delete beats an older add from the other device', () {
+      final mine = SyncMeta()..markAdded(_liked, 'x', at: 100);
+      final theirs = SyncMeta()..markDeleted(_liked, 'x', at: 500);
+      mine.mergeFrom(theirs);
+
+      expect(mine.isAlive(_liked, 'x'), isFalse);
+    });
+
+    test('an add beats an older delete', () {
+      final mine = SyncMeta()..markDeleted(_liked, 'x', at: 100);
+      final theirs = SyncMeta()..markAdded(_liked, 'x', at: 500);
+      mine.mergeFrom(theirs);
+
+      expect(mine.isAlive(_liked, 'x'), isTrue);
+    });
+
+    test('merging is order-independent on an exact tie', () {
+      // Caught a real bug: the tie-break used to keep "whichever is mine", so
+      // two devices merging the same pair reached opposite answers and wrote
+      // both back, flipping the item's state forever.
+      SyncMeta a() => SyncMeta()..markAdded(_liked, 'x', at: 300);
+      SyncMeta b() => SyncMeta()..markDeleted(_liked, 'x', at: 300);
+
+      final ab = a()..mergeFrom(b());
+      final ba = b()..mergeFrom(a());
+
+      expect(ab.isAlive(_liked, 'x'), ba.isAlive(_liked, 'x'));
+      // Deletion takes the tie: resurrecting is the failure that matters.
+      expect(ab.isAlive(_liked, 'x'), isFalse);
+    });
+  });
+
+  group('items with no metadata', () {
+    test('survive, because they predate sync', () {
+      // A library that existed before this feature has no records at all.
+      // Dropping it to fix a bookkeeping gap would be deleting a user's data.
+      final merged = mergeItems(
+        collection: _liked,
+        local: [_song('old1'), _song('old2')],
+        remote: const [],
+        meta: SyncMeta(),
+      );
+
+      expect(merged.map((s) => s.id), ['old1', 'old2']);
+    });
+  });
+
+  group('item merging', () {
+    test('unions both sides and keeps local order first', () {
+      final merged = mergeItems(
+        collection: _liked,
+        local: [_song('a'), _song('b')],
+        remote: [_song('c'), _song('a')],
+        meta: SyncMeta(),
+      );
+
+      expect(merged.map((s) => s.id), ['a', 'b', 'c']);
+    });
+
+    test('the local copy of a shared item is kept', () {
+      // It is at least as good as the remote and may carry enrichment the
+      // other device never fetched.
+      final local = FeedItem(
+        id: 'a',
+        title: 'Full Title',
+        type: 'song',
+        image: const [],
+        subtitle: 'Artist',
+      );
+      final remote = FeedItem(
+        id: 'a',
+        title: 'a',
+        type: 'song',
+        image: const [],
+      );
+
+      final merged = mergeItems(
+        collection: _liked,
+        local: [local],
+        remote: [remote],
+        meta: SyncMeta(),
+      );
+
+      expect(merged.single.subtitle, 'Artist');
+    });
+
+    test('items with no id are dropped rather than colliding', () {
+      final merged = mergeItems(
+        collection: _liked,
+        local: [FeedItem(id: '', title: 'junk', type: 'song', image: const [])],
+        remote: const [],
+        meta: SyncMeta(),
+      );
+
+      expect(merged, isEmpty);
+    });
+  });
+
+  group('tombstone pruning', () {
+    test('old tombstones are dropped, live records never are', () {
+      final now = DateTime(2026, 6, 1);
+      final meta = SyncMeta()
+        ..markDeleted(
+          _liked,
+          'ancient',
+          at: now.subtract(const Duration(days: 200)).millisecondsSinceEpoch,
+        )
+        ..markDeleted(
+          _liked,
+          'recent',
+          at: now.subtract(const Duration(days: 10)).millisecondsSinceEpoch,
+        )
+        ..markAdded(
+          _liked,
+          'alive',
+          at: now.subtract(const Duration(days: 900)).millisecondsSinceEpoch,
+        );
+
+      final pruned = meta.pruneTombstones(now: now);
+
+      expect(pruned, 1);
+      expect(meta.record(_liked, 'ancient'), isNull);
+      expect(meta.record(_liked, 'recent'), isNotNull);
+      expect(
+        meta.record(_liked, 'alive'),
+        isNotNull,
+        reason: 'live records are the collection, however old',
+      );
+    });
+  });
+
+  group('serialisation', () {
+    test('round-trips through JSON', () {
+      final meta = SyncMeta()
+        ..markAdded(_liked, 'a', at: 111)
+        ..markDeleted(_liked, 'b', at: 222);
+
+      final back = SyncMeta.fromJson(meta.toJson());
+
+      expect(back.record(_liked, 'a')!.at, 111);
+      expect(back.record(_liked, 'a')!.deleted, isFalse);
+      expect(back.record(_liked, 'b')!.at, 222);
+      expect(back.record(_liked, 'b')!.deleted, isTrue);
+    });
+
+    test('malformed metadata degrades to empty rather than throwing', () {
+      // The file comes from a folder the user controls, so it can be anything.
+      expect(SyncMeta.fromJson(null).length, 0);
+      expect(SyncMeta.fromJson('nonsense').length, 0);
+      expect(SyncMeta.fromJson({'k': 'not a record'}).length, 0);
+      expect(
+        SyncMeta.fromJson({
+          'k': {'no': 'at'},
+        }).length,
+        0,
+      );
+    });
+  });
+
+  group('episode progress', () {
+    test('the furthest position wins, not the newest write', () {
+      // Resuming earlier than you actually reached is the annoying failure.
+      final merged = mergeProgress(
+        local: {'ep1': 600, 'ep2': 30},
+        remote: {'ep1': 120, 'ep3': 45},
+      );
+
+      expect(merged['ep1'], 600);
+      expect(merged['ep2'], 30);
+      expect(merged['ep3'], 45);
+    });
+  });
+}

--- a/test/sync_merge_test.dart
+++ b/test/sync_merge_test.dart
@@ -111,19 +111,14 @@ void main() {
     test('the local copy of a shared item is kept', () {
       // It is at least as good as the remote and may carry enrichment the
       // other device never fetched.
-      final local = FeedItem(
+      const local = FeedItem(
         id: 'a',
         title: 'Full Title',
         type: 'song',
-        image: const [],
+        image: [],
         subtitle: 'Artist',
       );
-      final remote = FeedItem(
-        id: 'a',
-        title: 'a',
-        type: 'song',
-        image: const [],
-      );
+      const remote = FeedItem(id: 'a', title: 'a', type: 'song', image: []);
 
       final merged = mergeItems(
         collection: _liked,
@@ -138,7 +133,7 @@ void main() {
     test('items with no id are dropped rather than colliding', () {
       final merged = mergeItems(
         collection: _liked,
-        local: [FeedItem(id: '', title: 'junk', type: 'song', image: const [])],
+        local: [const FeedItem(id: '', title: 'junk', type: 'song', image: [])],
         remote: const [],
         meta: SyncMeta(),
       );


### PR DESCRIPTION
Two features that both come down to "the library is yours, on your terms": keeping it the same across two phones, and deciding which folders on the phone count as music.

## Library sync

Liked songs, playlists, saved albums and artists, podcast subscriptions, episode progress and settings, kept the same on two phones with **no account, no server of ours, and no cloud SDK in the app**.

sunoh writes an encrypted file into a folder you pick with the system picker. Whatever syncs that folder — Syncthing, Nextcloud, a Drive folder — moves it. sunoh never learns where the folder actually lives.

Design notes are in `docs/SYNC.md`. The decisions worth knowing:

- **No cloud API.** Drive sync means the Drive REST API, which means Google Sign-In, which means Play Services. That would contradict "No account. No sign-in, ever." in the README and the store listing, and take F-Droid from one removable blocker to two. The Storage Access Framework gets the same outcome with none of it.
- **One file per device.** Each phone writes `sunoh-<id>.sync` and reads every `.sync` file it can decrypt. Two devices never write the same file, so there is no locking problem and no last-writer-clobbers — the failure every "one shared JSON in a cloud folder" design hits.
- **Deletions are recorded, not merely absent.** Unliking a song on one phone and then union-merging with the other puts it back on both. That tombstone is why the merge file exists at all. Ties go to the deletion; an earlier version kept "whichever record is mine", so two devices reached opposite answers and flipped an item's state forever. Tombstones prune on a 90-day window.
- **Episode progress merges on furthest position**, not newest write. **User playlists merge per playlist on `updatedAt`**, not per song — a silently interleaved track order is worse than losing the older of two edits.
- **AES-128-GCM natively**, via `javax.crypto` in `SyncBridge.kt`, so no crypto dependency is added while F-Droid inclusion is open. Fresh IV per write, because the same library is re-encrypted on every change. The key is shown once as a recovery code and never leaves the device.
- **Deliberately not synced:** downloads (absolute paths, huge audio), queue and position (per-device), history, search recents. The table in `docs/SYNC.md` says why for each.
- Settings arriving in a payload are filtered against an allow-list — the file comes out of a directory the user controls, so it is treated as untrusted input.

13 merge tests cover the cases a two-phone setup actually produces.

## Music folders

A phone's audio is not all music. Ringtones, voice notes, forwarded WhatsApp audio and another app's podcast downloads all land in MediaStore, and neither the `IS_MUSIC` flag nor the duration floor keeps them out.

Library → On this device → folder icon is a tree of every folder holding audio, with the device itself as the row at the top.

| What you want | How |
|---|---|
| Everything except the ringtones | Leave the top row on, turn one folder off |
| Only one library | Turn the top row off, turn that folder on |
| A tree, minus one album inside it | Turn the tree on, turn that album off |

It is one rule set, not two lists: a default for the device plus per-folder overrides, resolved by taking the nearest rule up the path. This matters because **an include-only list silently drops music added later** — a folder created after the list was made is not on it — and an exclude-only list cannot say "only this one" without naming every sibling. Both failures are silent. The default is a visible row precisely because it is what folders that do not exist yet will follow.

Rules set by hand are never tidied away for being redundant. A rule can say nothing today and be the only thing keeping an album out tomorrow; dropping it in between resurrects music far from the tap that caused it. An earlier version pruned by comparing a rule to the new default, which threw away exactly the rules a folder in between made load-bearing — that lost an exclusion on a real device and has three regression tests now.

The choice is not synced between devices: the same music sits under different paths on different phones.

## Also here

- The folder screen builds its row tree once per scan rather than sorting and counting depths quadratically inside `build()`.
- An empty `if` block and a stale comment left behind when analytics was removed.
- Two lints in the sync screen, and an unused import.

## Testing

169 tests pass; the analyzer reports nothing new.

Verified on a real device: 67 tracks across 24 folders; turning the device row off, one tree on and one album inside it off gives 61, the album's rule survives the default being flipped, and the state survives a restart.

**Sync has not been run between two real phones.** The merge core is unit-tested and the round trip through a real synced folder is not. `docs/SYNC.md` says so rather than implying otherwise, and whether Google Drive specifically can be picked as a tree is still unverified — the design works with any folder-syncing app regardless.
