### PR TITLE
Optional YouTube Music sign-in, and a shared sheet shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ interface.**
 YouTube Music, Gaana and Saavn behind a single search — plus the music already
 on your phone, podcasts, and audiobooks.
 
-No ads. No account. No analytics. No sign-in, ever.
+No ads. No analytics. No account of ours. Optional YouTube sign-in, kept on your phone.
 
 [![Release](https://img.shields.io/github/v/release/afkcodes/sunoh?style=for-the-badge&label=release&color=D97757)](https://github.com/afkcodes/sunoh/releases/latest)
 [![Total downloads](https://img.shields.io/github/downloads/afkcodes/sunoh/total?style=for-the-badge&label=downloads&color=82B07B)](https://github.com/afkcodes/sunoh/releases)
@@ -113,9 +113,16 @@ drops, and downloaded tracks are the only tier that survives it.
 
 ## Privacy
 
-sunoh has no accounts and no user identity, and that is deliberate.
+sunoh has no account of its own and no user identity, and that is deliberate.
 
-- No sign-in, anywhere.
+- **No sunoh account, ever.** There is nothing to register for, and no server
+  of ours that knows who you are.
+- **YouTube sign-in is optional and local.** You can sign in to YouTube Music
+  to get your own recommendations and library. It uses Google's own sign-in
+  page in a web view, so your password is never seen by this app. The session
+  it produces is encrypted with a key held in the Android Keystore, stays on
+  the phone, is never sent to us, and is never included in library sync. Sign
+  out and it is deleted. Everything works without it.
 - **No analytics of any kind.** There is no telemetry SDK in the app — Firebase
   was removed outright rather than left switchable, so there is nothing to opt
   out of and nothing to take on trust.
@@ -247,8 +254,9 @@ trademarks belong to their respective owners.
   circumventing anything. Upstream platforms change without notice, and any
   given source can stop working at any time.
 
-- **Privacy.** No account, no sign-in, no analytics, and no listening history
-  leaving the phone. On-device music never leaves the device at all. See
+- **Privacy.** No account of ours, no analytics, and no listening history
+  leaving the phone. YouTube sign-in is optional, and its session never leaves
+  the device. On-device music never leaves the device at all. See
   [Privacy](#privacy) above.
 
 - **Copyleft.** sunoh is free software under the **GPL-3.0** — see

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -47,6 +47,16 @@
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher"
         android:usesCleartextTraffic="true">
+        <!-- Google's own sign-in page, in a WebView. Not exported: nothing
+             outside the app may start it, because what it hands back is a
+             session cookie. See auth/YtLoginActivity.kt for why a WebView is
+             the only option Google leaves a third-party client. -->
+        <activity
+            android:name=".auth.YtLoginActivity"
+            android:exported="false"
+            android:label="@string/yt_login_title"
+            android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/kotlin/codes/afk/sunoh/MainActivity.kt
+++ b/android/app/src/main/kotlin/codes/afk/sunoh/MainActivity.kt
@@ -1,6 +1,9 @@
 package codes.afk.sunoh
 
 import android.content.Intent
+import codes.afk.sunoh.auth.YtAuthBridge
+import codes.afk.sunoh.auth.YtAuthStore
+import codes.afk.sunoh.auth.YtLoginActivity
 import codes.afk.sunoh.localmedia.LocalMediaBridge
 import codes.afk.sunoh.sync.SyncBridge
 import codes.afk.sunoh.ytmusic.YtMusicBridge
@@ -49,10 +52,19 @@ class MainActivity : AudioServiceActivity() {
      */
     private var pendingFolderResult: Result? = null
 
+    /**
+     * Held across the sign-in WebView, for the same reason as the folder
+     * picker: the answer arrives through onActivityResult. Backing out of a
+     * sign-in returns false rather than an error — changing your mind about
+     * signing in is a normal thing to do.
+     */
+    private var pendingLoginResult: Result? = null
+
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
         YtMusicBridge.initialize(applicationContext)
+        YtAuthBridge.restore(applicationContext)
 
         // Stream resolution for the YouTube Music tier. Lives natively because
         // the required BotGuard PO token can only be minted by running
@@ -232,6 +244,51 @@ class MainActivity : AudioServiceActivity() {
                     else -> result.notImplemented()
                 }
             }
+
+        // The signed-in YouTube session. Native because the cookie is a
+        // credential held in the Keystore-backed store: Dart asks for headers
+        // and never holds the cookie itself. See YtAuthBridge.
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, AUTH_CHANNEL)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "state" -> result.success(
+                        mapOf(
+                            "signedIn" to YtAuthBridge.isSignedIn(),
+                            "accountName" to YtAuthBridge.accountName(),
+                            "visitorData" to YtAuthBridge.visitorData(),
+                        ),
+                    )
+
+                    "signIn" -> {
+                        if (pendingLoginResult != null) {
+                            result.error("busy", "sign-in already open", null)
+                        } else {
+                            pendingLoginResult = result
+                            startActivityForResult(
+                                Intent(this, YtLoginActivity::class.java),
+                                LOGIN_REQUEST,
+                            )
+                        }
+                    }
+
+                    "signOut" -> {
+                        YtAuthBridge.signOut(applicationContext)
+                        result.success(null)
+                    }
+
+                    // Recomputed per call: the SAPISIDHASH covers a timestamp,
+                    // so a cached header goes stale.
+                    "headers" -> result.success(YtAuthBridge.headers())
+
+                    "setAccountName" -> {
+                        val name = call.argument<String>("name").orEmpty()
+                        YtAuthBridge.rename(applicationContext, name)
+                        result.success(null)
+                    }
+
+                    else -> result.notImplemented()
+                }
+            }
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -247,6 +304,34 @@ class MainActivity : AudioServiceActivity() {
             }
             return
         }
+        if (requestCode == LOGIN_REQUEST) {
+            val pending = pendingLoginResult
+            pendingLoginResult = null
+            val cookie = data?.getStringExtra(YtLoginActivity.EXTRA_COOKIE)
+            if (resultCode != RESULT_OK || cookie.isNullOrBlank()) {
+                pending?.success(false)
+            } else {
+                YtAuthBridge.save(
+                    applicationContext,
+                    YtAuthStore.Session(
+                        cookie = cookie,
+                        visitorData = data.getStringExtra(
+                            YtLoginActivity.EXTRA_VISITOR_DATA,
+                        ).orEmpty(),
+                        dataSyncId = data.getStringExtra(
+                            YtLoginActivity.EXTRA_DATA_SYNC_ID,
+                        ).orEmpty(),
+                        authUser = "0",
+                        // Filled in by Dart once it has asked YouTube who this
+                        // is — the name lives in a browse response, and the
+                        // renderer parsing for those is all on that side.
+                        accountName = "",
+                    ),
+                )
+                pending?.success(true)
+            }
+            return
+        }
         super.onActivityResult(requestCode, resultCode, data)
     }
 
@@ -254,5 +339,7 @@ class MainActivity : AudioServiceActivity() {
         const val CHANNEL = "codes.afk.sunoh/ytmusic"
         const val LOCAL_CHANNEL = "codes.afk.sunoh/localmedia"
         const val SYNC_CHANNEL = "codes.afk.sunoh/sync"
+        const val AUTH_CHANNEL = "codes.afk.sunoh/ytauth"
+        const val LOGIN_REQUEST = 4711
     }
 }

--- a/android/app/src/main/kotlin/codes/afk/sunoh/auth/YtAuthBridge.kt
+++ b/android/app/src/main/kotlin/codes/afk/sunoh/auth/YtAuthBridge.kt
@@ -1,0 +1,142 @@
+package codes.afk.sunoh.auth
+
+import android.content.Context
+import android.util.Log
+import android.webkit.CookieManager
+import java.security.MessageDigest
+
+/**
+ * The signed-in YouTube session, and the one place that turns it into request
+ * headers.
+ *
+ * InnerTube authenticates the way the web client does: the cookie, plus an
+ * `Authorization` header holding a SHA-1 over the timestamp, the `SAPISID`
+ * cookie value and the origin. There is no token exchange and nothing to
+ * refresh — the signature is recomputed per request from a cookie the browser
+ * would hold anyway.
+ *
+ * Kept native rather than in Dart because the cookie lives here, in the
+ * Keystore-backed store, and handing it across the method channel on every
+ * request would mean copying a credential through a Dart string on every home
+ * refresh. Dart asks for headers; it never holds the cookie.
+ */
+object YtAuthBridge {
+
+    private const val TAG = "YtAuth"
+    private const val ORIGIN = "https://music.youtube.com"
+
+    @Volatile
+    private var cached: YtAuthStore.Session? = null
+
+    fun restore(context: Context) {
+        cached = YtAuthStore.load(context)
+        Log.i(TAG, "restored session: ${cached != null}")
+    }
+
+    fun isSignedIn(): Boolean = cached != null
+
+    fun accountName(): String = cached?.accountName.orEmpty()
+
+    fun save(context: Context, session: YtAuthStore.Session) {
+        YtAuthStore.save(context, session)
+        cached = session
+    }
+
+    /**
+     * Record who the session belongs to, once Dart has asked YouTube. Only the
+     * display name changes; the credential is left exactly as stored.
+     */
+    fun rename(context: Context, name: String) {
+        val session = cached ?: return
+        if (session.accountName == name) return
+        val updated = session.copy(accountName = name)
+        YtAuthStore.save(context, updated)
+        cached = updated
+    }
+
+    /**
+     * Sign out everywhere it counts: the stored session, the in-memory copy,
+     * and the WebView cookie jar. Leaving the jar populated would let the next
+     * sign-in silently resume the same account, which is not what someone who
+     * just signed out asked for.
+     */
+    fun signOut(context: Context) {
+        YtAuthStore.clear(context)
+        cached = null
+        runCatching {
+            CookieManager.getInstance().removeAllCookies(null)
+            CookieManager.getInstance().flush()
+        }
+        Log.i(TAG, "signed out")
+    }
+
+    /**
+     * Headers for one authenticated InnerTube call, or empty when signed out —
+     * in which case the caller sends exactly what it sent before, and the
+     * anonymous path is unchanged.
+     */
+    fun headers(): Map<String, String> {
+        val session = cached ?: return emptyMap()
+        val sapisid = sapisidOf(session.cookie) ?: return emptyMap()
+        val headers = mutableMapOf(
+            "Cookie" to session.cookie,
+            "Authorization" to sapisidHash(sapisid),
+            "X-Goog-AuthUser" to session.authUser,
+            // X-Origin has to match the origin inside the signature, or the
+            // signature is checked against the wrong string and the request is
+            // answered as if it were anonymous.
+            "X-Origin" to ORIGIN,
+            "X-Goog-Api-Format-Version" to "1",
+        )
+        if (session.visitorData.isNotBlank()) {
+            headers["X-Goog-Visitor-Id"] = session.visitorData
+        }
+        // dataSyncId is deliberately NOT sent as X-Goog-PageId.
+        //
+        // That was a guess, and a costly one: X-Goog-PageId names a channel to
+        // act as, and a dataSyncId is not a channel id. YouTube answered for an
+        // identity that did not exist — an account menu with no account in it,
+        // and a home feed with nothing personal on it, while every header
+        // looked present and correct. It is kept in the session because
+        // switching brand channels will need it, and it belongs in the request
+        // context rather than in a header.
+        return headers
+    }
+
+    /** `visitorData` belongs in the request context too, not just a header. */
+    fun visitorData(): String = cached?.visitorData.orEmpty()
+
+    /**
+     * `SAPISIDHASH <unix seconds>_<sha1(seconds + " " + SAPISID + " " + origin)>`.
+     *
+     * The timestamp is inside the digest, so a captured header is only good
+     * for the window YouTube allows — which is why the hash is computed per
+     * request rather than stored.
+     */
+    private fun sapisidHash(sapisid: String): String {
+        val seconds = System.currentTimeMillis() / 1000
+        val digest = sha1("$seconds $sapisid $ORIGIN")
+        return "SAPISIDHASH ${seconds}_$digest"
+    }
+
+    private fun sha1(input: String): String =
+        MessageDigest.getInstance("SHA-1")
+            .digest(input.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+
+    /**
+     * `SAPISID` proper, falling back to the `__Secure-3PAPISID` twin that some
+     * accounts get instead. Without one of them there is nothing to sign with
+     * and the session is not usable, however complete it otherwise looks.
+     */
+    private fun sapisidOf(cookie: String): String? {
+        val pairs = cookie.split(";")
+            .mapNotNull { part ->
+                val bits = part.trim().split("=", limit = 2)
+                if (bits.size == 2) bits[0].trim() to bits[1].trim() else null
+            }
+            .toMap()
+        return pairs["SAPISID"]?.takeIf { it.isNotBlank() }
+            ?: pairs["__Secure-3PAPISID"]?.takeIf { it.isNotBlank() }
+    }
+}

--- a/android/app/src/main/kotlin/codes/afk/sunoh/auth/YtAuthStore.kt
+++ b/android/app/src/main/kotlin/codes/afk/sunoh/auth/YtAuthStore.kt
@@ -1,0 +1,157 @@
+package codes.afk.sunoh.auth
+
+import android.content.Context
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import android.util.Log
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+/**
+ * Where the YouTube session lives on this device.
+ *
+ * What is held here is a Google session cookie: whoever has it can act as the
+ * signed-in user on YouTube. It is therefore treated as a credential rather
+ * than as a setting.
+ *
+ *  - **Encrypted at rest with a key held in the Android Keystore.** The key
+ *    material never enters the app's address space and cannot be pulled out of
+ *    an `adb backup` or a copied `shared_prefs` file, which a plain
+ *    SharedPreferences string can.
+ *  - **Not in the Hive settings box.** That box is what library sync writes
+ *    into a folder a cloud client uploads. A credential must never take that
+ *    path, and keeping it in a different store means it cannot be added to the
+ *    sync allow-list by accident.
+ *  - **Never logged.** Not the cookie, not a prefix of it. The account name and
+ *    a boolean are the only things about a session that ever reach a log line.
+ *
+ * `androidx.security:security-crypto` would do the same job. It is not used
+ * because the platform already provides all of it, and dependency count is not
+ * free while F-Droid inclusion is open — the same reasoning as SyncBridge.
+ */
+object YtAuthStore {
+
+    private const val TAG = "YtAuthStore"
+    private const val PREFS = "yt_auth"
+    private const val KEY_ALIAS = "sunoh.yt_auth.v1"
+    private const val GCM_TAG_BITS = 128
+    private const val IV_BYTES = 12
+
+    private const val K_COOKIE = "cookie"
+    private const val K_VISITOR = "visitor_data"
+    private const val K_DATA_SYNC = "data_sync_id"
+    private const val K_AUTH_USER = "auth_user"
+    private const val K_ACCOUNT = "account_name"
+
+    /** Everything needed to speak to InnerTube as the signed-in user. */
+    data class Session(
+        val cookie: String,
+        val visitorData: String,
+        val dataSyncId: String,
+        val authUser: String,
+        val accountName: String,
+    )
+
+    fun save(context: Context, session: Session) {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        prefs.edit()
+            .putString(K_COOKIE, seal(session.cookie))
+            .putString(K_VISITOR, seal(session.visitorData))
+            .putString(K_DATA_SYNC, seal(session.dataSyncId))
+            .putString(K_AUTH_USER, session.authUser)
+            // Shown in the UI, and not a credential on its own.
+            .putString(K_ACCOUNT, session.accountName)
+            .apply()
+    }
+
+    fun load(context: Context): Session? {
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val cookie = open(prefs.getString(K_COOKIE, null)) ?: return null
+        if (cookie.isBlank()) return null
+        return Session(
+            cookie = cookie,
+            visitorData = open(prefs.getString(K_VISITOR, null)).orEmpty(),
+            dataSyncId = open(prefs.getString(K_DATA_SYNC, null)).orEmpty(),
+            authUser = prefs.getString(K_AUTH_USER, null) ?: "0",
+            accountName = prefs.getString(K_ACCOUNT, null).orEmpty(),
+        )
+    }
+
+    /**
+     * Forget the session. The Keystore key goes too, so anything that somehow
+     * survives in a backup of the prefs file is undecryptable rather than
+     * merely orphaned.
+     */
+    fun clear(context: Context) {
+        context.getSharedPreferences(PREFS, Context.MODE_PRIVATE).edit().clear().apply()
+        runCatching {
+            KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+                .deleteEntry(KEY_ALIAS)
+        }
+    }
+
+    private fun secretKey(): SecretKey {
+        val ks = KeyStore.getInstance("AndroidKeyStore").apply { load(null) }
+        (ks.getEntry(KEY_ALIAS, null) as? KeyStore.SecretKeyEntry)?.let { return it.secretKey }
+        val generator = KeyGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_AES,
+            "AndroidKeyStore",
+        )
+        generator.init(
+            KeyGenParameterSpec.Builder(
+                KEY_ALIAS,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                // Deliberately not setUserAuthenticationRequired: the session is
+                // read on a cold start to render the home feed, long before
+                // there is a UI to prompt on.
+                .build(),
+        )
+        return generator.generateKey()
+    }
+
+    /** AES-GCM with the IV prepended, base64 for SharedPreferences. */
+    private fun seal(plain: String): String? = try {
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey())
+        val body = cipher.doFinal(plain.toByteArray(Charsets.UTF_8))
+        Base64.encodeToString(cipher.iv + body, Base64.NO_WRAP)
+    } catch (e: Exception) {
+        // No cookie text in the log, only that sealing failed.
+        Log.w(TAG, "could not seal session value: ${e.javaClass.simpleName}")
+        null
+    }
+
+    /**
+     * Null on anything unreadable rather than throwing. A Keystore key can go
+     * away on its own — a device restore, or the user clearing the secure
+     * lock screen — and the honest response is "you are signed out", not a
+     * crash on launch.
+     */
+    private fun open(stored: String?): String? {
+        if (stored.isNullOrBlank()) return null
+        return try {
+            val blob = Base64.decode(stored, Base64.NO_WRAP)
+            if (blob.size <= IV_BYTES) return null
+            val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+            cipher.init(
+                Cipher.DECRYPT_MODE,
+                secretKey(),
+                GCMParameterSpec(GCM_TAG_BITS, blob, 0, IV_BYTES),
+            )
+            String(
+                cipher.doFinal(blob, IV_BYTES, blob.size - IV_BYTES),
+                Charsets.UTF_8,
+            )
+        } catch (e: Exception) {
+            Log.w(TAG, "could not open session value: ${e.javaClass.simpleName}")
+            null
+        }
+    }
+}

--- a/android/app/src/main/kotlin/codes/afk/sunoh/auth/YtLoginActivity.kt
+++ b/android/app/src/main/kotlin/codes/afk/sunoh/auth/YtLoginActivity.kt
@@ -1,0 +1,225 @@
+package codes.afk.sunoh.auth
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+import android.view.ViewGroup
+import android.webkit.CookieManager
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.FrameLayout
+
+/**
+ * Signs in to YouTube with Google's own web flow, in a WebView.
+ *
+ * There is no other way. Google publishes no OAuth scope that gives a third
+ * party access to YouTube Music, so every client that offers this — Metrolist,
+ * InnerTune — signs in through the web page and keeps the resulting cookie.
+ * Doing it in a WebView rather than an embedded form matters: the password is
+ * typed into Google's page, over Google's TLS, and this app never sees it. All
+ * that comes back is the session cookie the browser would have held anyway.
+ *
+ * Three things are collected once the login lands:
+ *
+ *  - the cookie for `music.youtube.com`, which carries `SAPISID` — the value
+ *    the request signature is derived from, and the marker for "actually
+ *    signed in" rather than "page loaded";
+ *  - `VISITOR_DATA`, which pins the session to a consistent identity;
+ *  - `DATASYNC_ID`, which says *which* profile of a multi-profile Google
+ *    account is active. Without it, an account with brand channels serves a
+ *    different library than the one picked on screen.
+ *
+ * The last two only exist in `ytcfg` on a music.youtube.com page, which is why
+ * the flow continues there rather than stopping at the accounts domain.
+ */
+class YtLoginActivity : Activity() {
+
+    private var webView: WebView? = null
+
+    /** Set once, so a redirect chain cannot deliver two results. */
+    private var settled = false
+
+    @Volatile private var visitorData: String = ""
+
+    @Volatile private var dataSyncId: String = ""
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val view = WebView(this)
+        webView = view
+        setContentView(
+            FrameLayout(this).apply {
+                addView(
+                    view,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+            },
+        )
+
+        CookieManager.getInstance().setAcceptCookie(true)
+        CookieManager.getInstance().setAcceptThirdPartyCookies(view, true)
+
+        view.settings.apply {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            setSupportZoom(true)
+            builtInZoomControls = true
+            displayZoomControls = false
+        }
+        // The user agent is deliberately left alone.
+        //
+        // Claiming to be desktop Chrome is the obvious move and it backfires:
+        // Google checks the claim against the JS environment, and a desktop
+        // string on a WebView that has none of desktop Chrome's surface reads
+        // as evasion. That is exactly what "This browser or app may not be
+        // secure" means, and spoofing the string is what earns it. The stock
+        // WebView agent, honestly presented, is what gets through — this is
+        // also what Metrolist does, and why its sign-in works.
+
+        view.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(webView: WebView?, url: String?) {
+                super.onPageFinished(webView, url)
+                // Host, not substring: a sign-in URL can carry
+                // "music.youtube.com" in its continue= parameter while still
+                // being an accounts.google.com page with no ytcfg to read.
+                val host = runCatching { Uri.parse(url).host }.getOrNull()
+                if (host != "music.youtube.com") return
+                probe(attempt = 0)
+            }
+        }
+
+        view.loadUrl(LOGIN_URL)
+    }
+
+    /**
+     * Ask the page for its config, and keep asking.
+     *
+     * YouTube Music is a single-page app: `onPageFinished` fires when the
+     * document is done, which is well before its scripts have populated
+     * `ytcfg`. A single read a moment later finds nothing, and an earlier
+     * version of this treated that as "not signed in" — so a user who really
+     * had signed in sat on a loaded page while the app waited for a value that
+     * had already been read too early and would never be read again.
+     *
+     * ytcfg rather than scraping HTML: it is the same source the web client
+     * reads these from.
+     */
+    private fun probe(attempt: Int) {
+        val view = webView ?: return
+        if (settled) return
+
+        view.evaluateJavascript(CONFIG_JS) { raw ->
+            val parts = unquote(raw).split('|')
+            parts.getOrNull(0)?.takeIf { it.isNotBlank() }?.let { visitorData = it }
+            parts.getOrNull(1)?.takeIf { it.isNotBlank() }?.let { dataSyncId = it }
+
+            // Out of attempts is not failure. visitorData sharpens a session;
+            // the cookie and the signature are what authenticate it, so a
+            // session without one is worth keeping rather than discarding.
+            val lastChance = attempt >= MAX_PROBES
+            if (visitorData.isNotBlank() || lastChance) {
+                settleIfSignedIn(giveUpOnVisitorData = lastChance)
+                if (!settled && !lastChance) view.postDelayed({ probe(attempt + 1) }, PROBE_DELAY_MS)
+            } else {
+                view.postDelayed({ probe(attempt + 1) }, PROBE_DELAY_MS)
+            }
+        }
+    }
+
+    /**
+     * Finish only once the cookie actually carries SAPISID. Every earlier page
+     * in the flow — the account chooser, the password step, a consent screen —
+     * sets cookies too, and treating any of them as success hands back a
+     * session that cannot sign a single request.
+     */
+    private fun settleIfSignedIn(giveUpOnVisitorData: Boolean) {
+        if (settled) return
+        CookieManager.getInstance().flush()
+        val cookie = CookieManager.getInstance().getCookie(MUSIC_URL).orEmpty()
+        if (!cookie.contains("SAPISID")) {
+            Log.i(TAG, "on music.youtube.com but no SAPISID cookie yet")
+            return
+        }
+        if (visitorData.isBlank() && !giveUpOnVisitorData) return
+
+        settled = true
+        Log.i(
+            TAG,
+            "signed in (visitorData=${visitorData.isNotBlank()}, " +
+                "dataSyncId=${dataSyncId.isNotBlank()})",
+        )
+        setResult(
+            RESULT_OK,
+            Intent().apply {
+                putExtra(EXTRA_COOKIE, cookie)
+                putExtra(EXTRA_VISITOR_DATA, visitorData)
+                putExtra(EXTRA_DATA_SYNC_ID, dataSyncId)
+            },
+        )
+        finish()
+    }
+
+    override fun onDestroy() {
+        webView?.let { view ->
+            view.stopLoading()
+            (view.parent as? ViewGroup)?.removeView(view)
+            view.destroy()
+        }
+        webView = null
+        super.onDestroy()
+    }
+
+    @Suppress("DEPRECATION")
+    override fun onBackPressed() {
+        val view = webView
+        // Back walks the sign-in flow first. Only once there is nothing to go
+        // back to does it mean "I changed my mind", which is a cancel and not
+        // an error.
+        if (view != null && view.canGoBack()) {
+            view.goBack()
+        } else {
+            setResult(RESULT_CANCELED)
+            super.onBackPressed()
+        }
+    }
+
+    /**
+     * evaluateJavascript hands back a JSON literal, so a plain string arrives
+     * wrapped in quotes and `null` arrives as the four characters.
+     */
+    private fun unquote(raw: String?): String {
+        if (raw == null || raw == "null") return ""
+        return raw.removeSurrounding("\"").replace("\\\"", "\"")
+    }
+
+    companion object {
+        private const val TAG = "YtLogin"
+        const val EXTRA_COOKIE = "cookie"
+        const val EXTRA_VISITOR_DATA = "visitorData"
+        const val EXTRA_DATA_SYNC_ID = "dataSyncId"
+
+        private const val MUSIC_URL = "https://music.youtube.com"
+        private const val LOGIN_URL =
+            "https://accounts.google.com/ServiceLogin" +
+                "?continue=https%3A%2F%2Fmusic.youtube.com"
+
+        private const val PROBE_DELAY_MS = 500L
+
+        /** ~10s of retries. A slow page must not cost a completed sign-in. */
+        private const val MAX_PROBES = 20
+
+        /**
+         * Both values in one call, pipe-joined — two round trips through the
+         * JS bridge would have to be correlated, and there is nothing to gain
+         * from reading them a frame apart.
+         */
+        private const val CONFIG_JS =
+            "(function(){try{" +
+                "return (ytcfg.get('VISITOR_DATA')||'')+'|'+(ytcfg.get('DATASYNC_ID')||'');" +
+                "}catch(e){return '|';}})();"
+    }
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Shown in the task switcher while Google's sign-in page is open. The
+         app's own UI is Flutter, so this is one of the few strings Android
+         itself needs. -->
+    <string name="yt_login_title">Sign in to YouTube Music</string>
+</resources>

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,7 +1,7 @@
 sunoh plays music from YouTube Music, Gaana and Saavn behind a single search,
 alongside the music already stored on your phone. Podcasts and audiobooks too.
 
-No ads. No account. No analytics. No sign-in, ever.
+No ads. No analytics. No account of ours. Optional YouTube sign-in, kept on your phone.
 
 Sources
 
@@ -36,8 +36,13 @@ import from Spotify.
 
 Privacy
 
-No sign-in anywhere, and no analytics of any kind - there is no telemetry SDK
+No account of ours, and no analytics of any kind - there is no telemetry SDK
 in the app. On-device music never leaves the phone.
+
+You can optionally sign in to YouTube Music for your own recommendations and
+library. That uses Google's own sign-in page, so this app never sees your
+password, and the session is encrypted and kept on your phone. Everything
+works without it.
 
 sunoh is an independent client, not affiliated with or endorsed by any of the
 services it reaches, and hosts no media of its own.

--- a/lib/api/yt_auth_channel.dart
+++ b/lib/api/yt_auth_channel.dart
@@ -1,0 +1,102 @@
+// The signed-in YouTube session, as seen from Dart.
+//
+// Dart never holds the cookie. It asks the native side for the headers of one
+// request and forgets them: the credential stays in the Keystore-backed store
+// on the other side of the channel, and the SAPISIDHASH covers a timestamp, so
+// a header set is only good for one call anyway.
+//
+// Every method degrades to "signed out" rather than throwing. Being signed in
+// is an enhancement to a client that works fine without one, and no failure
+// here should be able to take out the anonymous path.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+/// What the app knows about the signed-in account. Nothing here is secret.
+class YtAccount {
+  const YtAccount({
+    this.signedIn = false,
+    this.name = '',
+    this.visitorData = '',
+  });
+
+  final bool signedIn;
+
+  /// Display name, empty until it has been asked for. Shown in Settings so
+  /// there is never any doubt about which account the home feed belongs to.
+  final String name;
+
+  /// Pins requests to one identity. Needed in the request context as well as
+  /// in a header, which is why it comes back to Dart at all.
+  final String visitorData;
+
+  static const signedOut = YtAccount();
+}
+
+class YtAuthChannel {
+  YtAuthChannel._();
+  static final YtAuthChannel instance = YtAuthChannel._();
+
+  static const MethodChannel _channel = MethodChannel('codes.afk.sunoh/ytauth');
+
+  bool get _supported => defaultTargetPlatform == TargetPlatform.android;
+
+  Future<YtAccount> state() async {
+    if (!_supported) return YtAccount.signedOut;
+    try {
+      final raw = await _channel.invokeMapMethod<String, Object?>('state');
+      if (raw == null) return YtAccount.signedOut;
+      return YtAccount(
+        signedIn: raw['signedIn'] == true,
+        name: (raw['accountName'] ?? '').toString(),
+        visitorData: (raw['visitorData'] ?? '').toString(),
+      );
+    } on PlatformException catch (e) {
+      debugPrint('[ytauth] state failed: ${e.code}');
+      return YtAccount.signedOut;
+    }
+  }
+
+  /// Opens Google's sign-in page. False when the user backed out, which is a
+  /// normal outcome and not an error.
+  Future<bool> signIn() async {
+    if (!_supported) return false;
+    try {
+      return await _channel.invokeMethod<bool>('signIn') ?? false;
+    } on PlatformException catch (e) {
+      debugPrint('[ytauth] signIn failed: ${e.code}');
+      return false;
+    }
+  }
+
+  Future<void> signOut() async {
+    if (!_supported) return;
+    try {
+      await _channel.invokeMethod<void>('signOut');
+    } on PlatformException catch (e) {
+      debugPrint('[ytauth] signOut failed: ${e.code}');
+    }
+  }
+
+  /// Headers for one authenticated InnerTube call. Empty when signed out, in
+  /// which case the caller sends what it always sent.
+  Future<Map<String, String>> headers() async {
+    if (!_supported) return const {};
+    try {
+      final raw = await _channel.invokeMapMethod<String, String>('headers');
+      return raw ?? const {};
+    } on PlatformException catch (e) {
+      debugPrint('[ytauth] headers failed: ${e.code}');
+      return const {};
+    }
+  }
+
+  Future<void> setAccountName(String name) async {
+    if (!_supported) return;
+    try {
+      await _channel.invokeMethod<void>('setAccountName', {'name': name});
+    } on PlatformException catch (e) {
+      debugPrint('[ytauth] setAccountName failed: ${e.code}');
+    }
+  }
+}

--- a/lib/api/ytmusic_account.dart
+++ b/lib/api/ytmusic_account.dart
@@ -1,0 +1,138 @@
+// What a signed-in YouTube account adds: who you are, and your own library.
+//
+// The personalized home feed is deliberately not here. `home()` already
+// browses `FEmusic_home`, and once a session exists every call through `_post`
+// carries its headers — so the same request that returns generic charts
+// signed out returns Quick picks and Listen again signed in. Writing a second
+// "personalized home" path would mean two ways to fetch one page, which drift.
+//
+// Only the endpoints that are meaningless without an account live here.
+
+part of 'ytmusic_api.dart';
+
+/// Library browse ids. Opaque to us; these are what the web client asks for.
+const _kLikedSongs = 'FEmusic_liked_videos';
+const _kLikedPlaylists = 'FEmusic_liked_playlists';
+const _kLikedAlbums = 'FEmusic_liked_albums';
+const _kLibraryArtists = 'FEmusic_library_corpus_track_artists';
+
+extension YtMusicAccount on YtMusicApi {
+  /// The signed-in account's display name, or null when the session is not
+  /// usable. Worth calling right after sign-in for that second reason as much
+  /// as the first: it is the cheapest proof that the cookie actually
+  /// authenticates, rather than merely existing.
+  Future<String?> accountName() async {
+    try {
+      final body = await _post('account/account_menu', _context);
+      if (body == null) return null;
+      final header = _findRenderer(body, 'activeAccountHeaderRenderer');
+      final name = _nodeText(_asMap(header?['accountName']));
+      return name.isEmpty ? null : name;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// Your own library: liked songs, playlists, albums and artists.
+  ///
+  /// Fetched concurrently, and a page that fails contributes nothing rather
+  /// than failing the lot — the same rule the home feed follows, and it
+  /// matters more here, because these four are independent and a signed-in
+  /// user with no saved albums is not an error.
+  Future<List<HomeSection>> library() async {
+    final pages = await Future.wait([
+      _libraryPage(_kLikedSongs, 'Liked songs'),
+      _libraryPage(_kLikedPlaylists, 'Your playlists'),
+      _libraryPage(_kLikedAlbums, 'Your albums'),
+      _libraryPage(_kLibraryArtists, 'Your artists'),
+    ]);
+    return [for (final page in pages) ?page];
+  }
+
+  /// One library page as a single section.
+  ///
+  /// Library pages come back as grids and lists rather than the carousels the
+  /// home feed uses, so the shelf parsing is different — but the heading is
+  /// ours rather than YouTube's, because these pages title themselves things
+  /// like "Playlists" that read wrong beside our own library's rows.
+  Future<HomeSection?> _libraryPage(String browseId, String heading) async {
+    try {
+      final body = await _post('browse', {..._context, 'browseId': browseId});
+      if (body == null) return null;
+      final items = _libraryItems(_singleColumnShelves(body));
+      if (items.isEmpty) return null;
+      return HomeSection(heading: heading, items: items, source: 'youtube');
+    } catch (_) {
+      return null;
+    }
+  }
+}
+
+/// Items out of a library page's grids and shelves.
+///
+/// Three shapes, because YouTube uses all three on these pages: a grid of
+/// two-row cards (albums, playlists, artists), a list shelf of responsive
+/// rows (liked songs), and occasionally a carousel like the home feed's.
+List<FeedItem> _libraryItems(List<Map<String, dynamic>> shelves) {
+  final items = <FeedItem>[];
+  for (final shelf in shelves) {
+    final containers = [
+      _asMap(shelf['gridRenderer']),
+      _asMap(shelf['musicShelfRenderer']),
+      _asMap(shelf['musicCarouselShelfRenderer']),
+    ];
+    for (final container in containers) {
+      if (container == null) continue;
+      for (final raw in [
+        ..._asList(container['items']),
+        ..._asList(container['contents']),
+      ]) {
+        final m = _asMap(raw);
+        if (m == null) continue;
+        final item = _parseTwoRowItem(m) ?? _parseResponsiveItem(m);
+        if (item != null) items.add(item);
+      }
+    }
+  }
+  return items;
+}
+
+/// The first renderer stored under [key], anywhere in the tree.
+///
+/// A hardcoded path was tried twice and moved twice: the account name sat
+/// under `multiPageMenuRenderer.header` in the shape this was written against
+/// and under `sections` in the one YouTube actually returns. Searching for the
+/// renderer by name survives that reshuffling, which is the only thing that
+/// can be relied on in a tree this volatile.
+///
+/// Depth-limited, because the response is large and the answer is always near
+/// the top; an unbounded walk would be a lot of work to find nothing on the
+/// day the renderer is renamed.
+Map<String, dynamic>? _findRenderer(Object? node, String key, [int depth = 0]) {
+  if (depth > 12) return null;
+  if (node is Map) {
+    final here = node[key];
+    if (here is Map) return here.cast<String, dynamic>();
+    for (final value in node.values) {
+      final found = _findRenderer(value, key, depth + 1);
+      if (found != null) return found;
+    }
+  } else if (node is List) {
+    for (final value in node) {
+      final found = _findRenderer(value, key, depth + 1);
+      if (found != null) return found;
+    }
+  }
+  return null;
+}
+
+/// Text out of a node that may carry either shape. InnerTube uses `runs` for
+/// anything that could be styled and `simpleText` when it never is, and which
+/// one a given field uses is not stable.
+String _nodeText(Map<String, dynamic>? node) {
+  if (node == null) return '';
+  final runs = _runsText(node);
+  if (runs.isNotEmpty) return runs;
+  final simple = node['simpleText'];
+  return simple is String ? simple : '';
+}

--- a/lib/api/ytmusic_api.dart
+++ b/lib/api/ytmusic_api.dart
@@ -16,7 +16,18 @@
 import 'package:dio/dio.dart';
 
 import 'dto.dart';
+import 'yt_auth_channel.dart';
 import 'yt_locale.dart';
+
+/// Renderer-tree parsing. See the file header there for why it is split out.
+part 'ytmusic_renderers.dart';
+
+/// The signed-in surface: account identity and your own library.
+part 'ytmusic_account.dart';
+
+/// Supplies the headers for one authenticated InnerTube call, or an empty map
+/// when signed out.
+typedef AuthHeaders = Future<Map<String, String>> Function();
 
 /// The YouTube Music web client. No API key or auth needed for search/browse.
 const _kClientName = 'WEB_REMIX';
@@ -108,8 +119,13 @@ class YtArtistDetail {
 }
 
 class YtMusicApi {
-  YtMusicApi(this._dio, {this.locale = YtLocale.fallback});
+  YtMusicApi(this._dio, {this.locale = YtLocale.fallback, AuthHeaders? auth})
+    : _auth = auth ?? YtAuthChannel.instance.headers;
   final Dio _dio;
+
+  /// Where the signed-in session's headers come from, injectable so a test can
+  /// drive both the anonymous and authenticated paths without a device.
+  final AuthHeaders _auth;
 
   /// Region and interface language for every request. `gl` in particular
   /// decides which charts and home rows come back, so a wrong value is the
@@ -127,26 +143,59 @@ class YtMusicApi {
     },
   };
 
-  Options get _options => Options(
+  Options _optionsWith(Map<String, String> auth) => Options(
     headers: {
       'Content-Type': 'application/json',
       'X-Youtube-Client-Name': '67',
       'X-Youtube-Client-Version': _kClientVersion,
       'Origin': 'https://music.youtube.com',
+      ...auth,
     },
     validateStatus: (s) => s != null && s < 500,
   );
 
+  /// Every call goes through here, which is why authentication is applied
+  /// here and nowhere else: signing in changes what search, browse and next
+  /// return, and a caller that had to remember to ask for it would eventually
+  /// forget on one path and serve a signed-in user someone else's home page.
+  ///
+  /// Signed out, [auth] is empty and the request is byte-for-byte what it was
+  /// before any of this existed.
   Future<Map<String, dynamic>?> _post(
     String path,
     Map<String, dynamic> body,
   ) async {
+    final auth = await _auth();
     final res = await _dio.post<Map<String, dynamic>>(
       '$_kBase/$path?prettyPrint=false',
-      data: body,
-      options: _options,
+      data: _withVisitorData(body, auth['X-Goog-Visitor-Id']),
+      options: _optionsWith(auth),
     );
     return res.data;
+  }
+
+  /// InnerTube wants `visitorData` in the request context as well as in the
+  /// header. Injected here rather than in [_context] so the call sites stay as
+  /// they are, and so an anonymous request keeps the exact body it had.
+  static Map<String, dynamic> _withVisitorData(
+    Map<String, dynamic> body,
+    String? visitorData,
+  ) {
+    if (visitorData == null || visitorData.isEmpty) return body;
+    final context = body['context'];
+    if (context is! Map) return body;
+    final client = context['client'];
+    if (client is! Map) return body;
+    return {
+      ...body,
+      'context': {
+        ...context.cast<String, dynamic>(),
+        'client': {
+          ...client.cast<String, dynamic>(),
+          'visitorData': visitorData,
+        },
+      },
+    };
   }
 
   // ── Public API ────────────────────────────────────────────────────────
@@ -613,421 +662,4 @@ class YtMusicApi {
     stationType: item.stationType,
     mediaUrls: item.mediaUrls,
   );
-
-  // ── Renderer navigation ───────────────────────────────────────────────
-
-  List<HomeSection> _carouselSections(List<Map<String, dynamic>> shelves) {
-    final sections = <HomeSection>[];
-    for (final shelf in shelves) {
-      final carousel = _asMap(shelf['musicCarouselShelfRenderer']);
-      if (carousel == null) continue;
-      final heading = _runsText(
-        _asMap(
-          _dig(carousel, [
-            'header',
-            'musicCarouselShelfBasicHeaderRenderer',
-            'title',
-          ]),
-        ),
-      );
-      final items = <FeedItem>[];
-      for (final raw in _asList(carousel['contents'])) {
-        final m = _asMap(raw);
-        if (m == null) continue;
-        final item = _parseTwoRowItem(m) ?? _parseResponsiveItem(m);
-        if (item != null) items.add(item);
-      }
-      if (items.isNotEmpty) {
-        sections.add(
-          HomeSection(
-            heading: heading.isEmpty ? 'YouTube Music' : heading,
-            items: items,
-            source: 'youtube',
-          ),
-        );
-      }
-    }
-    return sections;
-  }
-
-  List<Map<String, dynamic>> _searchShelves(Map<String, dynamic> body) {
-    final tabs = _asList(
-      _dig(body, ['contents', 'tabbedSearchResultsRenderer', 'tabs']),
-    );
-    for (final tab in tabs) {
-      final shelves = <Map<String, dynamic>>[];
-      for (final c in _asList(
-        _dig(_asMap(tab), [
-          'tabRenderer',
-          'content',
-          'sectionListRenderer',
-          'contents',
-        ]),
-      )) {
-        final shelf = _asMap(_asMap(c)?['musicShelfRenderer']);
-        if (shelf != null) shelves.add(shelf);
-      }
-      if (shelves.isNotEmpty) return shelves;
-    }
-    return const [];
-  }
-
-  List<Map<String, dynamic>> _singleColumnShelves(Map<String, dynamic> body) {
-    final tabs = _asList(
-      _dig(body, ['contents', 'singleColumnBrowseResultsRenderer', 'tabs']),
-    );
-    for (final tab in tabs) {
-      final contents = _asList(
-        _dig(_asMap(tab), [
-          'tabRenderer',
-          'content',
-          'sectionListRenderer',
-          'contents',
-        ]),
-      );
-      if (contents.isNotEmpty) {
-        return contents.map(_asMap).whereType<Map<String, dynamic>>().toList();
-      }
-    }
-    return const [];
-  }
-
-  // ── Item parsing ──────────────────────────────────────────────────────
-
-  /// `musicResponsiveListItemRenderer` — search results, playlist tracks.
-  FeedItem? _parseResponsiveItem(Map<String, dynamic>? wrapper) {
-    final r = _asMap(wrapper?['musicResponsiveListItemRenderer']);
-    if (r == null) return null;
-
-    final cols = _asList(r['flexColumns']);
-    final title = _flexColumnText(cols, 0);
-    if (title.isEmpty) return null;
-
-    final videoId = _videoIdOf(r);
-    if (videoId == null) {
-      // Not a track. List shelves also carry artists and albums (the
-      // "Top artists" chart is 40 of them); without this they'd all be
-      // dropped for lacking a videoId.
-      final nav = _asMap(r['navigationEndpoint']);
-      final browseId = _asMap(nav?['browseEndpoint'])?['browseId'] as String?;
-      if (browseId == null || browseId.isEmpty) return null;
-      final type = switch (_pageTypeOf(nav)) {
-        'MUSIC_PAGE_TYPE_ARTIST' => 'artist',
-        'MUSIC_PAGE_TYPE_ALBUM' => 'album',
-        'MUSIC_PAGE_TYPE_PLAYLIST' => 'playlist',
-        _ => null,
-      };
-      if (type == null) return null;
-      final sub = _flexColumnText(cols, 1).trim();
-      return FeedItem(
-        id: browseId,
-        title: title,
-        type: type,
-        source: 'youtube',
-        image: _thumbnails(r),
-        subtitle: sub.isEmpty ? null : sub,
-      );
-    }
-
-    // Column 1 is a runs list joined by " • ": artist • album • duration.
-    // Every one of those is navigable, so "has a navigationEndpoint" does
-    // NOT mean "is an artist" — that mistake put album names in the artist
-    // line. Discriminate on the endpoint's pageType instead.
-    final subRuns = _flexColumnRuns(cols, 1);
-    final artists = <ApiArtistRef>[];
-    String? album;
-    String? duration;
-    for (final run in subRuns) {
-      final text = (run['text'] ?? '').toString();
-      final trimmed = text.trim();
-      if (trimmed.isEmpty || trimmed == '•') continue;
-
-      final secs = _durationToSeconds(trimmed);
-      if (secs != null) {
-        duration = '$secs';
-        continue;
-      }
-
-      final nav = _asMap(run['navigationEndpoint']);
-      switch (_pageTypeOf(nav)) {
-        case 'MUSIC_PAGE_TYPE_ARTIST':
-          // Keep the channel id, not just the name — it's what lets the
-          // player's "View artist" open the artist page.
-          artists.add(
-            ApiArtistRef(
-              id: (_asMap(nav?['browseEndpoint'])?['browseId'] ?? '')
-                  .toString(),
-              name: trimmed,
-            ),
-          );
-        case 'MUSIC_PAGE_TYPE_ALBUM':
-          album ??= trimmed;
-        case _:
-          // Un-navigable runs are usually the primary artist on tracks
-          // that have no artist channel (common for Art Tracks).
-          if (artists.isEmpty && album == null) {
-            artists.add(ApiArtistRef(id: '', name: trimmed));
-          }
-      }
-    }
-
-    // Column 2 carries play counts on search rows.
-    final third = _flexColumnText(cols, 2).trim();
-    final plays = third.toLowerCase().contains('play') ? third : null;
-
-    return FeedItem(
-      id: videoId,
-      title: title,
-      type: 'song',
-      source: 'youtube',
-      image: _thumbnails(r),
-      subtitle: artists.isEmpty ? album : artists.map((a) => a.name).join(', '),
-      duration: duration,
-      playCount: plays,
-      artists: List.unmodifiable(artists),
-    );
-  }
-
-  /// `musicTwoRowItemRenderer` — home / category carousel cards.
-  FeedItem? _parseTwoRowItem(Map<String, dynamic> wrapper) {
-    final r = _asMap(wrapper['musicTwoRowItemRenderer']);
-    if (r == null) return null;
-
-    final title = _runsText(_asMap(r['title']));
-    if (title.isEmpty) return null;
-    final subtitle = _runsText(_asMap(r['subtitle']));
-
-    final nav = _asMap(r['navigationEndpoint']);
-    final videoId = _asMap(nav?['watchEndpoint'])?['videoId'] as String?;
-    final browseId = _asMap(nav?['browseEndpoint'])?['browseId'] as String?;
-
-    // Type from the endpoint's declared pageType rather than guessing from
-    // the id prefix — YouTube uses several prefixes per kind.
-    final String id;
-    final String type;
-    if (videoId != null && videoId.isNotEmpty) {
-      id = videoId;
-      type = 'song';
-    } else if (browseId != null && browseId.isNotEmpty) {
-      id = browseId;
-      type = switch (_pageTypeOf(nav)) {
-        'MUSIC_PAGE_TYPE_ARTIST' => 'artist',
-        'MUSIC_PAGE_TYPE_ALBUM' => 'album',
-        _ => 'playlist',
-      };
-    } else {
-      return null;
-    }
-
-    return FeedItem(
-      id: id,
-      title: title,
-      type: type,
-      source: 'youtube',
-      image: _thumbnails(r),
-      subtitle: subtitle.isEmpty ? null : subtitle,
-    );
-  }
-
-  // ── Field extraction ──────────────────────────────────────────────────
-
-  String? _pageTypeOf(Map<String, dynamic>? navigationEndpoint) =>
-      _dig(navigationEndpoint, [
-            'browseEndpoint',
-            'browseEndpointContextSupportedConfigs',
-            'browseEndpointContextMusicConfig',
-            'pageType',
-          ])
-          as String?;
-
-  String? _videoIdOf(Map<String, dynamic> r) {
-    final fromPlaylistData =
-        _asMap(r['playlistItemData'])?['videoId'] as String?;
-    if (fromPlaylistData != null && fromPlaylistData.isNotEmpty) {
-      return fromPlaylistData;
-    }
-    final overlayId = _dig(r, [
-      'overlay',
-      'musicItemThumbnailOverlayRenderer',
-      'content',
-      'musicPlayButtonRenderer',
-      'playNavigationEndpoint',
-      'watchEndpoint',
-      'videoId',
-    ]);
-    if (overlayId is String && overlayId.isNotEmpty) return overlayId;
-    return null;
-  }
-
-  /// Thumbnails, from any of the three shapes YouTube uses.
-  ///
-  /// The renderers disagree, and picking only one silently yields no art —
-  /// the UI then falls back to generated covers, which reads as a styling
-  /// bug rather than a parsing one:
-  ///
-  ///   list rows          thumbnail.musicThumbnailRenderer.thumbnail.thumbnails
-  ///   carousel cards     thumbnailRenderer.musicThumbnailRenderer.…
-  ///   queue rows         thumbnail.thumbnails   (no wrapper at all)
-  ///
-  /// The last is what `/next` returns for radio queues.
-  List<ApiImage> _thumbnails(Map<String, dynamic> r) {
-    final candidates = <List<String>>[
-      ['thumbnail', 'musicThumbnailRenderer', 'thumbnail', 'thumbnails'],
-      [
-        'thumbnailRenderer',
-        'musicThumbnailRenderer',
-        'thumbnail',
-        'thumbnails',
-      ],
-      ['thumbnail', 'thumbnails'],
-    ];
-    for (final path in candidates) {
-      final thumbs = _asList(_dig(r, path));
-      if (thumbs.isEmpty) continue;
-      final out = <ApiImage>[];
-      for (final t in thumbs) {
-        final m = _asMap(t);
-        final url = m?['url'] as String?;
-        if (url == null || url.isEmpty) continue;
-        final w = (m?['width'] as num?)?.toInt();
-        final h = (m?['height'] as num?)?.toInt();
-        final upscaled = _upscale(url, w, h);
-        // Label with the size actually being requested, not the size the
-        // API offered — FeedItem.artwork picks the highest number here, so
-        // a stale label would have it choose a smaller image.
-        out.add(
-          ApiImage(
-            quality: upscaled.$2 == null ? '' : '${upscaled.$2}x${upscaled.$3}',
-            link: upscaled.$1,
-          ),
-        );
-      }
-      if (out.isNotEmpty) return out;
-    }
-    return const [];
-  }
-
-  /// Pick the biggest rendition from a variant list.
-  ///
-  /// Not `.last` — that only works while the API happens to return
-  /// ascending sizes, and a header rendered from the smallest variant is a
-  /// silent, hard-to-spot quality regression.
-  String? _largestArt(List<ApiImage> images) {
-    if (images.isEmpty) return null;
-    int width(ApiImage i) {
-      final m = RegExp(r'(\d+)').firstMatch(i.quality);
-      return m == null ? 0 : (int.tryParse(m.group(1)!) ?? 0);
-    }
-
-    final sorted = [...images]..sort((a, b) => width(b).compareTo(width(a)));
-    return sorted.first.link;
-  }
-
-  /// Largest square dimension worth requesting.
-  ///
-  /// Measured against the CDN: cover art tops out at 1200x1200 and any
-  /// larger request returns the identical bytes, so asking for more just
-  /// makes the URL look ambitious. 1200 also covers the expanded player's
-  /// 336pt hero at 3x density with room to spare.
-  static const _kMaxArtSize = 1200;
-
-  /// Ask Google's image CDN for a larger rendition.
-  ///
-  /// The sizes the API volunteers are small — 60px for search rows, 576
-  /// for chart covers — and get upscaled by the client, which is what made
-  /// hero images look blocky however large the display surface was.
-  ///
-  /// Two suffix forms are in use and BOTH have to be handled. Supporting
-  /// only the first left every chart and playlist cover at its original
-  /// size, since those use the second:
-  ///
-  ///   =w544-h544-l90-rj   sized, with modifiers
-  ///   =s576               square shorthand
-  ///
-  /// The size is rewritten in place so any trailing modifiers survive, and
-  /// the aspect ratio is taken from the URL itself rather than the JSON,
-  /// so wide artist banners don't get squared into a portrait crop.
-  ///
-  /// Returns the url plus the size it will actually be, so callers can
-  /// label it honestly.
-  (String, int?, int?) _upscale(String url, int? width, int? height) {
-    if (width != null && width >= _kMaxArtSize) return (url, width, height);
-
-    final square = RegExp(r'=s(\d+)').firstMatch(url);
-    if (square != null) {
-      return (
-        url.replaceRange(square.start, square.end, '=s$_kMaxArtSize'),
-        _kMaxArtSize,
-        _kMaxArtSize,
-      );
-    }
-
-    final sized = RegExp(r'=w(\d+)-h(\d+)').firstMatch(url);
-    if (sized != null) {
-      final w0 = int.tryParse(sized.group(1)!) ?? 0;
-      final h0 = int.tryParse(sized.group(2)!) ?? 0;
-      final h = (w0 > 0 && h0 > 0)
-          ? (_kMaxArtSize * h0 / w0).round()
-          : _kMaxArtSize;
-      return (
-        url.replaceRange(sized.start, sized.end, '=w$_kMaxArtSize-h$h'),
-        _kMaxArtSize,
-        h,
-      );
-    }
-
-    return (url, width, height);
-  }
-
-  String _flexColumnText(List<dynamic> cols, int index) => _flexColumnRuns(
-    cols,
-    index,
-  ).map((r) => (r['text'] ?? '').toString()).join();
-
-  List<Map<String, dynamic>> _flexColumnRuns(List<dynamic> cols, int index) {
-    if (index >= cols.length) return const [];
-    return _asList(
-      _dig(_asMap(cols[index]), [
-        'musicResponsiveListItemFlexColumnRenderer',
-        'text',
-        'runs',
-      ]),
-    ).map(_asMap).whereType<Map<String, dynamic>>().toList();
-  }
-
-  String _runsText(Map<String, dynamic>? node) => _asList(node?['runs'])
-      .map(_asMap)
-      .whereType<Map<String, dynamic>>()
-      .map((r) => (r['text'] ?? '').toString())
-      .join();
-
-  /// `3:42` / `1:02:11` -> total seconds. Null when [text] isn't a duration.
-  int? _durationToSeconds(String text) {
-    if (!RegExp(r'^\d{1,2}(:\d{2}){1,2}$').hasMatch(text)) return null;
-    final parts = text.split(':').map(int.parse).toList();
-    return switch (parts.length) {
-      2 => parts[0] * 60 + parts[1],
-      3 => parts[0] * 3600 + parts[1] * 60 + parts[2],
-      _ => null,
-    };
-  }
-
-  // ── Safe traversal ────────────────────────────────────────────────────
-
-  static Map<String, dynamic>? _asMap(Object? v) =>
-      v is Map ? v.cast<String, dynamic>() : null;
-
-  static List<dynamic> _asList(Object? v) => v is List ? v : const [];
-
-  /// Walk a path of string keys, returning null the moment anything isn't a
-  /// map. Keeps the renderer navigation above readable.
-  static Object? _dig(Map<String, dynamic>? node, List<String> path) {
-    Object? cur = node;
-    for (final key in path) {
-      final m = _asMap(cur);
-      if (m == null) return null;
-      cur = m[key];
-    }
-    return cur;
-  }
 }

--- a/lib/api/ytmusic_renderers.dart
+++ b/lib/api/ytmusic_renderers.dart
@@ -1,0 +1,425 @@
+// Turning InnerTube's renderer tree into our DTOs.
+//
+// Split from ytmusic_api.dart, which was carrying both halves of the job in
+// one 1076-line file: the transport and endpoint list on one side, and this on
+// the other. They change for entirely different reasons — an endpoint moves
+// when we want new content, these move when YouTube reshuffles its renderers —
+// and the split is along that seam.
+//
+// A `part` rather than its own library, deliberately: these read the private
+// helpers they sit beside and are private themselves. Nothing here is API.
+//
+// Everything is defensive. The tree is deeply nested, positional, and full of
+// optional keys, and a shape change upstream should cost a missing row, not an
+// exception.
+
+part of 'ytmusic_api.dart';
+// ── Renderer navigation ───────────────────────────────────────────────
+
+List<HomeSection> _carouselSections(List<Map<String, dynamic>> shelves) {
+  final sections = <HomeSection>[];
+  for (final shelf in shelves) {
+    final carousel = _asMap(shelf['musicCarouselShelfRenderer']);
+    if (carousel == null) continue;
+    final heading = _runsText(
+      _asMap(
+        _dig(carousel, [
+          'header',
+          'musicCarouselShelfBasicHeaderRenderer',
+          'title',
+        ]),
+      ),
+    );
+    final items = <FeedItem>[];
+    for (final raw in _asList(carousel['contents'])) {
+      final m = _asMap(raw);
+      if (m == null) continue;
+      final item = _parseTwoRowItem(m) ?? _parseResponsiveItem(m);
+      if (item != null) items.add(item);
+    }
+    if (items.isNotEmpty) {
+      sections.add(
+        HomeSection(
+          heading: heading.isEmpty ? 'YouTube Music' : heading,
+          items: items,
+          source: 'youtube',
+        ),
+      );
+    }
+  }
+  return sections;
+}
+
+List<Map<String, dynamic>> _searchShelves(Map<String, dynamic> body) {
+  final tabs = _asList(
+    _dig(body, ['contents', 'tabbedSearchResultsRenderer', 'tabs']),
+  );
+  for (final tab in tabs) {
+    final shelves = <Map<String, dynamic>>[];
+    for (final c in _asList(
+      _dig(_asMap(tab), [
+        'tabRenderer',
+        'content',
+        'sectionListRenderer',
+        'contents',
+      ]),
+    )) {
+      final shelf = _asMap(_asMap(c)?['musicShelfRenderer']);
+      if (shelf != null) shelves.add(shelf);
+    }
+    if (shelves.isNotEmpty) return shelves;
+  }
+  return const [];
+}
+
+List<Map<String, dynamic>> _singleColumnShelves(Map<String, dynamic> body) {
+  final tabs = _asList(
+    _dig(body, ['contents', 'singleColumnBrowseResultsRenderer', 'tabs']),
+  );
+  for (final tab in tabs) {
+    final contents = _asList(
+      _dig(_asMap(tab), [
+        'tabRenderer',
+        'content',
+        'sectionListRenderer',
+        'contents',
+      ]),
+    );
+    if (contents.isNotEmpty) {
+      return contents.map(_asMap).whereType<Map<String, dynamic>>().toList();
+    }
+  }
+  return const [];
+}
+
+// ── Item parsing ──────────────────────────────────────────────────────
+
+/// `musicResponsiveListItemRenderer` — search results, playlist tracks.
+FeedItem? _parseResponsiveItem(Map<String, dynamic>? wrapper) {
+  final r = _asMap(wrapper?['musicResponsiveListItemRenderer']);
+  if (r == null) return null;
+
+  final cols = _asList(r['flexColumns']);
+  final title = _flexColumnText(cols, 0);
+  if (title.isEmpty) return null;
+
+  final videoId = _videoIdOf(r);
+  if (videoId == null) {
+    // Not a track. List shelves also carry artists and albums (the
+    // "Top artists" chart is 40 of them); without this they'd all be
+    // dropped for lacking a videoId.
+    final nav = _asMap(r['navigationEndpoint']);
+    final browseId = _asMap(nav?['browseEndpoint'])?['browseId'] as String?;
+    if (browseId == null || browseId.isEmpty) return null;
+    final type = switch (_pageTypeOf(nav)) {
+      'MUSIC_PAGE_TYPE_ARTIST' => 'artist',
+      'MUSIC_PAGE_TYPE_ALBUM' => 'album',
+      'MUSIC_PAGE_TYPE_PLAYLIST' => 'playlist',
+      _ => null,
+    };
+    if (type == null) return null;
+    final sub = _flexColumnText(cols, 1).trim();
+    return FeedItem(
+      id: browseId,
+      title: title,
+      type: type,
+      source: 'youtube',
+      image: _thumbnails(r),
+      subtitle: sub.isEmpty ? null : sub,
+    );
+  }
+
+  // Column 1 is a runs list joined by " • ": artist • album • duration.
+  // Every one of those is navigable, so "has a navigationEndpoint" does
+  // NOT mean "is an artist" — that mistake put album names in the artist
+  // line. Discriminate on the endpoint's pageType instead.
+  final subRuns = _flexColumnRuns(cols, 1);
+  final artists = <ApiArtistRef>[];
+  String? album;
+  String? duration;
+  for (final run in subRuns) {
+    final text = (run['text'] ?? '').toString();
+    final trimmed = text.trim();
+    if (trimmed.isEmpty || trimmed == '•') continue;
+
+    final secs = _durationToSeconds(trimmed);
+    if (secs != null) {
+      duration = '$secs';
+      continue;
+    }
+
+    final nav = _asMap(run['navigationEndpoint']);
+    switch (_pageTypeOf(nav)) {
+      case 'MUSIC_PAGE_TYPE_ARTIST':
+        // Keep the channel id, not just the name — it's what lets the
+        // player's "View artist" open the artist page.
+        artists.add(
+          ApiArtistRef(
+            id: (_asMap(nav?['browseEndpoint'])?['browseId'] ?? '').toString(),
+            name: trimmed,
+          ),
+        );
+      case 'MUSIC_PAGE_TYPE_ALBUM':
+        album ??= trimmed;
+      case _:
+        // Un-navigable runs are usually the primary artist on tracks
+        // that have no artist channel (common for Art Tracks).
+        if (artists.isEmpty && album == null) {
+          artists.add(ApiArtistRef(id: '', name: trimmed));
+        }
+    }
+  }
+
+  // Column 2 carries play counts on search rows.
+  final third = _flexColumnText(cols, 2).trim();
+  final plays = third.toLowerCase().contains('play') ? third : null;
+
+  return FeedItem(
+    id: videoId,
+    title: title,
+    type: 'song',
+    source: 'youtube',
+    image: _thumbnails(r),
+    subtitle: artists.isEmpty ? album : artists.map((a) => a.name).join(', '),
+    duration: duration,
+    playCount: plays,
+    artists: List.unmodifiable(artists),
+  );
+}
+
+/// `musicTwoRowItemRenderer` — home / category carousel cards.
+FeedItem? _parseTwoRowItem(Map<String, dynamic> wrapper) {
+  final r = _asMap(wrapper['musicTwoRowItemRenderer']);
+  if (r == null) return null;
+
+  final title = _runsText(_asMap(r['title']));
+  if (title.isEmpty) return null;
+  final subtitle = _runsText(_asMap(r['subtitle']));
+
+  final nav = _asMap(r['navigationEndpoint']);
+  final videoId = _asMap(nav?['watchEndpoint'])?['videoId'] as String?;
+  final browseId = _asMap(nav?['browseEndpoint'])?['browseId'] as String?;
+
+  // Type from the endpoint's declared pageType rather than guessing from
+  // the id prefix — YouTube uses several prefixes per kind.
+  final String id;
+  final String type;
+  if (videoId != null && videoId.isNotEmpty) {
+    id = videoId;
+    type = 'song';
+  } else if (browseId != null && browseId.isNotEmpty) {
+    id = browseId;
+    type = switch (_pageTypeOf(nav)) {
+      'MUSIC_PAGE_TYPE_ARTIST' => 'artist',
+      'MUSIC_PAGE_TYPE_ALBUM' => 'album',
+      _ => 'playlist',
+    };
+  } else {
+    return null;
+  }
+
+  return FeedItem(
+    id: id,
+    title: title,
+    type: type,
+    source: 'youtube',
+    image: _thumbnails(r),
+    subtitle: subtitle.isEmpty ? null : subtitle,
+  );
+}
+
+// ── Field extraction ──────────────────────────────────────────────────
+
+String? _pageTypeOf(Map<String, dynamic>? navigationEndpoint) =>
+    _dig(navigationEndpoint, [
+          'browseEndpoint',
+          'browseEndpointContextSupportedConfigs',
+          'browseEndpointContextMusicConfig',
+          'pageType',
+        ])
+        as String?;
+
+String? _videoIdOf(Map<String, dynamic> r) {
+  final fromPlaylistData = _asMap(r['playlistItemData'])?['videoId'] as String?;
+  if (fromPlaylistData != null && fromPlaylistData.isNotEmpty) {
+    return fromPlaylistData;
+  }
+  final overlayId = _dig(r, [
+    'overlay',
+    'musicItemThumbnailOverlayRenderer',
+    'content',
+    'musicPlayButtonRenderer',
+    'playNavigationEndpoint',
+    'watchEndpoint',
+    'videoId',
+  ]);
+  if (overlayId is String && overlayId.isNotEmpty) return overlayId;
+  return null;
+}
+
+/// Thumbnails, from any of the three shapes YouTube uses.
+///
+/// The renderers disagree, and picking only one silently yields no art —
+/// the UI then falls back to generated covers, which reads as a styling
+/// bug rather than a parsing one:
+///
+///   list rows          thumbnail.musicThumbnailRenderer.thumbnail.thumbnails
+///   carousel cards     thumbnailRenderer.musicThumbnailRenderer.…
+///   queue rows         thumbnail.thumbnails   (no wrapper at all)
+///
+/// The last is what `/next` returns for radio queues.
+List<ApiImage> _thumbnails(Map<String, dynamic> r) {
+  final candidates = <List<String>>[
+    ['thumbnail', 'musicThumbnailRenderer', 'thumbnail', 'thumbnails'],
+    ['thumbnailRenderer', 'musicThumbnailRenderer', 'thumbnail', 'thumbnails'],
+    ['thumbnail', 'thumbnails'],
+  ];
+  for (final path in candidates) {
+    final thumbs = _asList(_dig(r, path));
+    if (thumbs.isEmpty) continue;
+    final out = <ApiImage>[];
+    for (final t in thumbs) {
+      final m = _asMap(t);
+      final url = m?['url'] as String?;
+      if (url == null || url.isEmpty) continue;
+      final w = (m?['width'] as num?)?.toInt();
+      final h = (m?['height'] as num?)?.toInt();
+      final upscaled = _upscale(url, w, h);
+      // Label with the size actually being requested, not the size the
+      // API offered — FeedItem.artwork picks the highest number here, so
+      // a stale label would have it choose a smaller image.
+      out.add(
+        ApiImage(
+          quality: upscaled.$2 == null ? '' : '${upscaled.$2}x${upscaled.$3}',
+          link: upscaled.$1,
+        ),
+      );
+    }
+    if (out.isNotEmpty) return out;
+  }
+  return const [];
+}
+
+/// Pick the biggest rendition from a variant list.
+///
+/// Not `.last` — that only works while the API happens to return
+/// ascending sizes, and a header rendered from the smallest variant is a
+/// silent, hard-to-spot quality regression.
+String? _largestArt(List<ApiImage> images) {
+  if (images.isEmpty) return null;
+  int width(ApiImage i) {
+    final m = RegExp(r'(\d+)').firstMatch(i.quality);
+    return m == null ? 0 : (int.tryParse(m.group(1)!) ?? 0);
+  }
+
+  final sorted = [...images]..sort((a, b) => width(b).compareTo(width(a)));
+  return sorted.first.link;
+}
+
+/// Largest square dimension worth requesting.
+///
+/// Measured against the CDN: cover art tops out at 1200x1200 and any
+/// larger request returns the identical bytes, so asking for more just
+/// makes the URL look ambitious. 1200 also covers the expanded player's
+/// 336pt hero at 3x density with room to spare.
+const _kMaxArtSize = 1200;
+
+/// Ask Google's image CDN for a larger rendition.
+///
+/// The sizes the API volunteers are small — 60px for search rows, 576
+/// for chart covers — and get upscaled by the client, which is what made
+/// hero images look blocky however large the display surface was.
+///
+/// Two suffix forms are in use and BOTH have to be handled. Supporting
+/// only the first left every chart and playlist cover at its original
+/// size, since those use the second:
+///
+///   =w544-h544-l90-rj   sized, with modifiers
+///   =s576               square shorthand
+///
+/// The size is rewritten in place so any trailing modifiers survive, and
+/// the aspect ratio is taken from the URL itself rather than the JSON,
+/// so wide artist banners don't get squared into a portrait crop.
+///
+/// Returns the url plus the size it will actually be, so callers can
+/// label it honestly.
+(String, int?, int?) _upscale(String url, int? width, int? height) {
+  if (width != null && width >= _kMaxArtSize) return (url, width, height);
+
+  final square = RegExp(r'=s(\d+)').firstMatch(url);
+  if (square != null) {
+    return (
+      url.replaceRange(square.start, square.end, '=s$_kMaxArtSize'),
+      _kMaxArtSize,
+      _kMaxArtSize,
+    );
+  }
+
+  final sized = RegExp(r'=w(\d+)-h(\d+)').firstMatch(url);
+  if (sized != null) {
+    final w0 = int.tryParse(sized.group(1)!) ?? 0;
+    final h0 = int.tryParse(sized.group(2)!) ?? 0;
+    final h = (w0 > 0 && h0 > 0)
+        ? (_kMaxArtSize * h0 / w0).round()
+        : _kMaxArtSize;
+    return (
+      url.replaceRange(sized.start, sized.end, '=w$_kMaxArtSize-h$h'),
+      _kMaxArtSize,
+      h,
+    );
+  }
+
+  return (url, width, height);
+}
+
+String _flexColumnText(List<dynamic> cols, int index) => _flexColumnRuns(
+  cols,
+  index,
+).map((r) => (r['text'] ?? '').toString()).join();
+
+List<Map<String, dynamic>> _flexColumnRuns(List<dynamic> cols, int index) {
+  if (index >= cols.length) return const [];
+  return _asList(
+    _dig(_asMap(cols[index]), [
+      'musicResponsiveListItemFlexColumnRenderer',
+      'text',
+      'runs',
+    ]),
+  ).map(_asMap).whereType<Map<String, dynamic>>().toList();
+}
+
+String _runsText(Map<String, dynamic>? node) => _asList(node?['runs'])
+    .map(_asMap)
+    .whereType<Map<String, dynamic>>()
+    .map((r) => (r['text'] ?? '').toString())
+    .join();
+
+/// `3:42` / `1:02:11` -> total seconds. Null when [text] isn't a duration.
+int? _durationToSeconds(String text) {
+  if (!RegExp(r'^\d{1,2}(:\d{2}){1,2}$').hasMatch(text)) return null;
+  final parts = text.split(':').map(int.parse).toList();
+  return switch (parts.length) {
+    2 => parts[0] * 60 + parts[1],
+    3 => parts[0] * 3600 + parts[1] * 60 + parts[2],
+    _ => null,
+  };
+}
+
+// ── Safe traversal ────────────────────────────────────────────────────
+
+Map<String, dynamic>? _asMap(Object? v) =>
+    v is Map ? v.cast<String, dynamic>() : null;
+
+List<dynamic> _asList(Object? v) => v is List ? v : const [];
+
+/// Walk a path of string keys, returning null the moment anything isn't a
+/// map. Keeps the renderer navigation above readable.
+Object? _dig(Map<String, dynamic>? node, List<String> path) {
+  Object? cur = node;
+  for (final key in path) {
+    final m = _asMap(cur);
+    if (m == null) return null;
+    cur = m[key];
+  }
+  return cur;
+}

--- a/lib/cast/cast_button.dart
+++ b/lib/cast/cast_button.dart
@@ -124,7 +124,7 @@ class _DevicePickerSheet extends ConsumerWidget {
         constraints: BoxConstraints(maxHeight: maxH),
         decoration: squircleDecoration(
           radius: 20,
-          color: const Color(0xFF15151A),
+          color: c.bgSoft,
           borderColor: c.line,
         ),
         padding: EdgeInsets.fromLTRB(0, 8, 0, 8 + topInset),

--- a/lib/overlays/add_to_playlist_sheet.dart
+++ b/lib/overlays/add_to_playlist_sheet.dart
@@ -50,7 +50,7 @@ class _AddToPlaylistSheet extends ConsumerWidget {
         constraints: BoxConstraints(maxHeight: maxH),
         decoration: squircleDecoration(
           radius: 20,
-          color: const Color(0xFF15151A),
+          color: c.bgSoft,
           borderColor: c.line,
         ),
         padding: EdgeInsets.fromLTRB(0, 8, 0, 8 + topInset),

--- a/lib/overlays/hero_menu_sheet.dart
+++ b/lib/overlays/hero_menu_sheet.dart
@@ -83,7 +83,7 @@ class _HeroMenuSheet extends ConsumerWidget {
         margin: const EdgeInsets.fromLTRB(8, 0, 8, 8),
         decoration: squircleDecoration(
           radius: 20,
-          color: const Color(0xFF15151A),
+          color: c.bgSoft,
           borderColor: c.line,
         ),
         padding: EdgeInsets.fromLTRB(0, 8, 0, 8 + topInset),

--- a/lib/overlays/language_sheet.dart
+++ b/lib/overlays/language_sheet.dart
@@ -42,7 +42,7 @@ class _LanguageSheet extends ConsumerWidget {
         constraints: BoxConstraints(maxHeight: maxH),
         decoration: squircleDecoration(
           radius: 20,
-          color: const Color(0xFF15151A),
+          color: c.bgSoft,
           borderColor: c.line,
         ),
         padding: EdgeInsets.fromLTRB(0, 8, 0, 8 + topInset),

--- a/lib/overlays/queue_menu_sheet.dart
+++ b/lib/overlays/queue_menu_sheet.dart
@@ -42,7 +42,7 @@ class _QueueMenuSheet extends ConsumerWidget {
         margin: const EdgeInsets.fromLTRB(8, 0, 8, 8),
         decoration: squircleDecoration(
           radius: 20,
-          color: const Color(0xFF15151A),
+          color: c.bgSoft,
           borderColor: c.line,
         ),
         padding: EdgeInsets.fromLTRB(0, 8, 0, 8 + topInset),

--- a/lib/overlays/sheet.dart
+++ b/lib/overlays/sheet.dart
@@ -1,0 +1,281 @@
+// The shape every bottom sheet in the app shares.
+//
+// Sheets were being built one at a time, and had drifted: each re-declared its
+// own radius, padding and handle, and each hardcoded `Color(0xFF15151A)` for
+// the background. That colour is a design-system violation twice over — a raw
+// value outside tokens.dart, and a dark one, so every sheet stayed dark in
+// light mode. `bgSoft` is the token for exactly this surface and it is what
+// this uses.
+//
+// A sheet rather than a dialog wherever there is a choice to make. A dialog
+// interrupts and sits under the thumb's reach at the top of a tall phone; a
+// sheet arrives from the edge the thumb is already near, can be dismissed by
+// pushing it back where it came from, and can grow to fit its content without
+// becoming a scrolling box floating in the middle of the screen.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../providers/app_state_provider.dart';
+import '../theme/tokens.dart';
+import '../widgets/ui.dart';
+
+/// Present [builder] as a sheet with the app's chrome.
+///
+/// [dismissible] false is for a sheet mid-operation — a download in flight has
+/// nothing useful to do with a stray backdrop tap.
+Future<T?> showSunohSheet<T>(
+  BuildContext context, {
+  required WidgetBuilder builder,
+  bool dismissible = true,
+}) {
+  return showModalBottomSheet<T>(
+    context: context,
+    backgroundColor: Colors.transparent,
+    isScrollControlled: true,
+    isDismissible: dismissible,
+    enableDrag: dismissible,
+    // The root navigator, not the branch one. A sheet pushed onto the shell's
+    // inner navigator is painted *under* the mini player and bottom nav, which
+    // are drawn over every page — so its buttons sit behind the player, which
+    // is exactly where they cannot be tapped.
+    useRootNavigator: true,
+    builder: builder,
+  );
+}
+
+/// The sheet shell: handle, optional header, body, optional actions.
+class SunohSheet extends ConsumerWidget {
+  const SunohSheet({
+    super.key,
+    required this.child,
+    this.title,
+    this.subtitle,
+    this.icon,
+    this.trailing,
+    this.actions,
+  });
+
+  final Widget child;
+  final String? title;
+  final String? subtitle;
+
+  /// Shown in an accent medallion beside the title. A sheet that names a
+  /// thing is easier to recognise at a glance than one that only describes it.
+  final IconData? icon;
+
+  /// Optional control on the header's right — a close affordance, usually.
+  final Widget? trailing;
+
+  /// Buttons along the bottom. Laid out by [SheetActions].
+  final Widget? actions;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final s = ref.watch(appStateProvider);
+    final c = s.colors;
+    final accent = s.resolvedAccent;
+    final media = MediaQuery.of(context);
+
+    return Padding(
+      // Lifts above the keyboard when a sheet contains a field.
+      padding: EdgeInsets.only(bottom: media.viewInsets.bottom),
+      child: SafeArea(
+        top: false,
+        child: Container(
+          margin: const EdgeInsets.fromLTRB(8, 0, 8, 8),
+          constraints: BoxConstraints(maxHeight: media.size.height * 0.88),
+          decoration: squircleDecoration(
+            radius: 22,
+            color: c.bgSoft,
+            borderColor: c.line,
+          ),
+          padding: const EdgeInsets.fromLTRB(0, 10, 0, 12),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _Handle(colors: c),
+              if (title != null)
+                _Header(
+                  title: title!,
+                  subtitle: subtitle,
+                  icon: icon,
+                  trailing: trailing,
+                  colors: c,
+                  accent: accent,
+                ),
+              // The body scrolls and the header and actions do not, so a long
+              // changelog cannot push the buttons off the bottom.
+              Flexible(child: SingleChildScrollView(child: child)),
+              if (actions != null)
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 14, 16, 4),
+                  child: actions,
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _Handle extends StatelessWidget {
+  const _Handle({required this.colors});
+  final SunohColors colors;
+
+  @override
+  Widget build(BuildContext context) => Center(
+    child: Container(
+      width: 34,
+      height: 4,
+      margin: const EdgeInsets.only(bottom: 12),
+      decoration: BoxDecoration(
+        color: colors.line,
+        borderRadius: BorderRadius.circular(2),
+      ),
+    ),
+  );
+}
+
+class _Header extends StatelessWidget {
+  const _Header({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.trailing,
+    required this.colors,
+    required this.accent,
+  });
+
+  final String title;
+  final String? subtitle;
+  final IconData? icon;
+  final Widget? trailing;
+  final SunohColors colors;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 12, 14),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (icon != null) ...[
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: accent.withValues(alpha: 0.18),
+                shape: BoxShape.circle,
+              ),
+              alignment: Alignment.center,
+              child: Icon(icon, size: 20, color: accent),
+            ),
+            const SizedBox(width: 12),
+          ],
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  title,
+                  style: SunohType.heading(
+                    fontSize: 18,
+                    color: c.fg,
+                    letterSpacing: -0.3,
+                  ),
+                ),
+                if ((subtitle ?? '').isNotEmpty) ...[
+                  const SizedBox(height: 3),
+                  Text(
+                    subtitle!,
+                    style: SunohType.sans(
+                      fontSize: 12.5,
+                      color: c.fgMute,
+                      height: 1.4,
+                    ),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          ?trailing,
+        ],
+      ),
+    );
+  }
+}
+
+/// One or two buttons along the bottom of a sheet.
+///
+/// The affirmative sits on the right, where a thumb travelling up the screen
+/// reaches it last — which is the correct order for something that commits.
+class SheetActions extends StatelessWidget {
+  const SheetActions({super.key, required this.primary, this.secondary});
+
+  final Widget primary;
+  final Widget? secondary;
+
+  @override
+  Widget build(BuildContext context) {
+    if (secondary == null) return primary;
+    return Row(
+      children: [
+        Expanded(child: secondary!),
+        const SizedBox(width: 10),
+        Expanded(child: primary),
+      ],
+    );
+  }
+}
+
+/// A sheet button. Filled reads as the action, outlined as the way out.
+class SheetButton extends ConsumerWidget {
+  const SheetButton({
+    super.key,
+    required this.label,
+    required this.onTap,
+    this.filled = false,
+  });
+
+  final String label;
+  final VoidCallback? onTap;
+  final bool filled;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final s = ref.watch(appStateProvider);
+    final c = s.colors;
+    final enabled = onTap != null;
+
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Opacity(
+        opacity: enabled ? 1 : 0.5,
+        child: Container(
+          alignment: Alignment.center,
+          padding: const EdgeInsets.symmetric(vertical: 13),
+          decoration: squircleDecoration(
+            radius: 999,
+            color: filled ? s.resolvedAccent : Colors.transparent,
+            borderColor: filled ? null : c.line,
+          ),
+          child: Text(
+            label,
+            style: SunohType.sans(
+              fontSize: 13.5,
+              fontWeight: FontWeight.w600,
+              color: filled ? c.onAccent : c.fg,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/overlays/sleep_sheet.dart
+++ b/lib/overlays/sleep_sheet.dart
@@ -52,7 +52,7 @@ class _SleepSheet extends ConsumerWidget {
         margin: const EdgeInsets.fromLTRB(8, 0, 8, 8),
         decoration: squircleDecoration(
           radius: 20,
-          color: const Color(0xFF15151A),
+          color: c.bgSoft,
           borderColor: c.line,
         ),
         padding: EdgeInsets.fromLTRB(0, 8, 0, 8 + topInset),

--- a/lib/overlays/track_menu_sheet.dart
+++ b/lib/overlays/track_menu_sheet.dart
@@ -150,7 +150,7 @@ class _TrackMenuSheet extends ConsumerWidget {
         margin: const EdgeInsets.fromLTRB(8, 0, 8, 8),
         decoration: squircleDecoration(
           radius: 20,
-          color: const Color(0xFF15151A),
+          color: c.bgSoft,
           borderColor: c.line,
         ),
         padding: EdgeInsets.fromLTRB(0, 8, 0, 8 + topInset),

--- a/lib/overlays/yt_locale_sheet.dart
+++ b/lib/overlays/yt_locale_sheet.dart
@@ -100,7 +100,7 @@ class _YtLocaleSheet extends ConsumerWidget {
         ),
         decoration: squircleDecoration(
           radius: 20,
-          color: const Color(0xFF15151A),
+          color: c.bgSoft,
           borderColor: c.line,
         ),
         padding: EdgeInsets.fromLTRB(0, 10, 0, 8 + bottomInset),

--- a/lib/overlays/yt_sign_out_sheet.dart
+++ b/lib/overlays/yt_sign_out_sheet.dart
@@ -1,0 +1,118 @@
+// Confirming a YouTube sign-out.
+//
+// Signing out is asked about and signing in is not, because the two are not
+// symmetrical: signing in adds a home feed, and signing out throws away the
+// session, empties the personal library shelves and drops the cookie. Getting
+// back means Google's login flow again, possibly with a second factor.
+//
+// The sheet says where the session actually lives. "Sign in with Google" in a
+// third-party app is exactly the kind of thing a careful person should be
+// suspicious of, and the honest answer is the reassuring one.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:solar_icons/solar_icons.dart';
+
+import '../providers/app_state_provider.dart';
+import '../theme/tokens.dart';
+import 'sheet.dart';
+
+/// True when the user confirmed. Dismissing the sheet is a no.
+Future<bool> showYtSignOutSheet(
+  BuildContext context,
+  String accountName,
+) async {
+  final result = await showSunohSheet<bool>(
+    context,
+    builder: (_) => _SignOutSheet(accountName: accountName),
+  );
+  return result ?? false;
+}
+
+class _SignOutSheet extends ConsumerWidget {
+  const _SignOutSheet({required this.accountName});
+  final String accountName;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final c = ref.watch(appStateProvider).colors;
+    return SunohSheet(
+      icon: SolarIconsOutline.logout,
+      title: 'Sign out of YouTube Music?',
+      subtitle: accountName.isEmpty ? null : accountName,
+      actions: SheetActions(
+        secondary: SheetButton(
+          label: 'Stay signed in',
+          onTap: () => Navigator.of(context).pop(false),
+        ),
+        primary: SheetButton(
+          label: 'Sign out',
+          filled: true,
+          onTap: () => Navigator.of(context).pop(true),
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _Point(
+              icon: SolarIconsOutline.playlistMinimalistic,
+              text:
+                  'Your recommendations and YouTube library shelves go back '
+                  'to the generic ones.',
+              colors: c,
+            ),
+            const SizedBox(height: 12),
+            _Point(
+              icon: SolarIconsOutline.heart,
+              text:
+                  'Everything you saved in sunoh stays. Nothing on your '
+                  'YouTube account is changed.',
+              colors: c,
+            ),
+            const SizedBox(height: 12),
+            _Point(
+              icon: SolarIconsOutline.shieldCheck,
+              text:
+                  'The session is deleted from this phone. It was only ever '
+                  'stored here, encrypted, and never sent anywhere.',
+              colors: c,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// One reassurance, with its own icon. A wall of prose in a confirmation is
+/// not read; three short lines with a mark against each are.
+class _Point extends StatelessWidget {
+  const _Point({required this.icon, required this.text, required this.colors});
+
+  final IconData icon;
+  final String text;
+  final SunohColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 1),
+          child: Icon(icon, size: 16, color: c.fgMute),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            text,
+            style: SunohType.sans(fontSize: 13, color: c.fgDim, height: 1.45),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/providers/yt_auth_provider.dart
+++ b/lib/providers/yt_auth_provider.dart
@@ -1,0 +1,109 @@
+// The signed-in YouTube account, as app state.
+//
+// Signing in is not a setting — it changes what every YouTube request returns,
+// so the feeds have to be thrown away and re-fetched on both sign-in and
+// sign-out. That invalidation is the reason this is a notifier rather than a
+// bare FutureProvider: something has to own the "and now refetch everything"
+// step, and doing it at each call site would mean forgetting it at one.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
+
+import '../api/yt_auth_channel.dart';
+import '../api/ytmusic_api.dart';
+import 'ytmusic_provider.dart';
+
+class YtAuthController extends ChangeNotifier {
+  YtAuthController(this._ref, {YtAuthChannel? channel})
+    : _channel = channel ?? YtAuthChannel.instance;
+
+  final Ref _ref;
+  final YtAuthChannel _channel;
+
+  YtAccount _account = YtAccount.signedOut;
+  YtAccount get account => _account;
+
+  bool get isSignedIn => _account.signedIn;
+
+  bool _busy = false;
+  bool get isBusy => _busy;
+
+  /// Read the stored session. Safe to call repeatedly.
+  Future<void> restore() async {
+    _account = await _channel.state();
+    notifyListeners();
+    // A session with no name yet is one that has never been confirmed against
+    // YouTube — either it was just created, or the name lookup failed last
+    // time. Asking again is cheap and doubles as a liveness check.
+    if (_account.signedIn && _account.name.isEmpty) {
+      await _refreshName();
+    }
+  }
+
+  Future<bool> signIn() async {
+    if (_busy) return false;
+    _busy = true;
+    notifyListeners();
+    try {
+      final ok = await _channel.signIn();
+      if (!ok) return false;
+      _account = await _channel.state();
+      await _refreshName();
+      _invalidateFeeds();
+      return true;
+    } finally {
+      _busy = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> signOut() async {
+    if (_busy) return;
+    _busy = true;
+    notifyListeners();
+    try {
+      await _channel.signOut();
+      _account = YtAccount.signedOut;
+      _invalidateFeeds();
+    } finally {
+      _busy = false;
+      notifyListeners();
+    }
+  }
+
+  /// Ask YouTube who this is, and keep the answer.
+  ///
+  /// A null answer is not treated as a failed sign-in. It means only that the
+  /// name could not be read — a renderer moved, the call timed out, the
+  /// account has no display name — and none of that says the cookie cannot
+  /// authenticate. An earlier version signed out here, which turned a parsing
+  /// bug into a session that appeared to sign in and then silently undid
+  /// itself, with the row still reading "Sign in".
+  ///
+  /// The session stays; the row says "Signed in" without a name.
+  Future<void> _refreshName() async {
+    final name = await _ref.read(ytMusicApiProvider).accountName();
+    if (name == null) {
+      debugPrint('[ytauth] signed in, but could not read the account name');
+      return;
+    }
+    await _channel.setAccountName(name);
+    _account = YtAccount(
+      signedIn: true,
+      name: name,
+      visitorData: _account.visitorData,
+    );
+    notifyListeners();
+  }
+
+  /// Every YouTube feed is now answering for a different identity.
+  void _invalidateFeeds() {
+    _ref.invalidate(ytMusicHomeProvider);
+    _ref.invalidate(ytMusicLibraryProvider);
+  }
+}
+
+final ytAuthProvider = ChangeNotifierProvider<YtAuthController>(
+  (ref) => YtAuthController(ref)..restore(),
+);

--- a/lib/providers/ytmusic_provider.dart
+++ b/lib/providers/ytmusic_provider.dart
@@ -10,6 +10,7 @@ import '../api/dto.dart';
 import '../api/yt_locale.dart';
 import '../api/ytmusic_api.dart';
 import 'app_state_provider.dart';
+import 'yt_auth_provider.dart';
 
 /// A Dio dedicated to music.youtube.com.
 ///
@@ -79,6 +80,17 @@ final ytMusicAlbumSearchProvider = FutureProvider.autoDispose
 /// The YouTube Music home feed, interleaved into the Music tab. Not
 /// autoDispose: it's a large response and the feed doesn't change minute to
 /// minute, so re-fetching on every tab switch would be wasteful.
+/// Your own YouTube library — liked songs, playlists, albums, artists.
+///
+/// Empty when signed out, rather than an error: the Library screen renders
+/// whatever sections it gets, and "no account" is simply no sections.
+final ytMusicLibraryProvider = FutureProvider<List<HomeSection>>((ref) {
+  if (!ref.watch(ytAuthProvider).isSignedIn) {
+    return Future.value(const <HomeSection>[]);
+  }
+  return ref.watch(ytMusicApiProvider).library();
+});
+
 final ytMusicHomeProvider = FutureProvider<List<HomeSection>>((ref) {
   return ref.watch(ytMusicApiProvider).home();
 });

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -20,7 +20,7 @@ import '../widgets/album_art.dart';
 import '../widgets/playing_bars.dart';
 import '../widgets/top_tabs.dart';
 import '../widgets/ui.dart';
-import '../widgets/update_dialog.dart';
+import '../widgets/update_sheet.dart';
 // Tab implementations: Music (the original /music/home feed), Podcasts
 // (backed by /podcasts/home via `podcastHomeProvider`, since v1.5.5),
 // and Audiobooks (cozyaudiobooks.com, since v1.8.0).
@@ -55,7 +55,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     if (updateInfo != null && _promptedVersion != updateInfo.version) {
       _promptedVersion = updateInfo.version;
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) showUpdateDialog(context, updateInfo);
+        if (mounted) showUpdateSheet(context, updateInfo);
       });
     }
 

--- a/lib/screens/library_screen.dart
+++ b/lib/screens/library_screen.dart
@@ -16,6 +16,7 @@ import '../data/models.dart';
 import '../providers/app_state_provider.dart';
 import '../providers/downloads_provider.dart';
 import '../providers/local_library_provider.dart';
+import '../providers/ytmusic_provider.dart';
 import '../router/router.dart';
 import '../state/app_state.dart';
 import '../theme/tokens.dart';
@@ -23,6 +24,7 @@ import '../widgets/album_art.dart';
 import '../widgets/ui.dart';
 import 'library_device_section.dart';
 import 'library_playlists.dart';
+import 'library_youtube_section.dart';
 import 'user_playlist_screen.dart';
 
 enum _LibFilter { all, playlists, albums, artists, songs }
@@ -264,6 +266,15 @@ class _LibraryScreenState extends ConsumerState<LibraryScreen> {
         Consumer(
           builder: (ctx, innerRef, _) => LibraryDeviceSection(
             library: innerRef.watch(localLibraryProvider),
+            colors: c,
+          ),
+        ),
+        // A signed-in YouTube account's own shelves. Absent when signed out.
+        Consumer(
+          builder: (ctx, innerRef, _) => LibraryYouTubeSection(
+            sections:
+                innerRef.watch(ytMusicLibraryProvider).asData?.value ??
+                const <HomeSection>[],
             colors: c,
           ),
         ),

--- a/lib/screens/library_youtube_section.dart
+++ b/lib/screens/library_youtube_section.dart
@@ -1,0 +1,147 @@
+// The Library tab's window onto a signed-in YouTube account.
+//
+// Same shape as the on-device section directly above it, and for the same
+// reason: covers you recognise are what make a shelf read as yours. A row of
+// text links would technically list the same playlists and feel like someone
+// else's data borrowed for the afternoon.
+//
+// Absent entirely when signed out. Not a prompt, not an empty state — the app
+// works without an account, and a permanent advert for signing in would say
+// otherwise. The invitation lives in Settings, once.
+
+import 'package:flutter/material.dart';
+
+import '../api/dto.dart';
+import '../router/router.dart';
+import '../theme/tokens.dart';
+import '../widgets/album_art.dart';
+import '../widgets/ui.dart';
+
+/// Covers per shelf before the row stops building cards nobody scrolled to.
+const int _kPreviewCount = 12;
+
+class LibraryYouTubeSection extends StatelessWidget {
+  const LibraryYouTubeSection({
+    super.key,
+    required this.sections,
+    required this.colors,
+  });
+
+  final List<HomeSection> sections;
+  final SunohColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final withItems = sections.where((s) => s.items.isNotEmpty).toList();
+    if (withItems.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final section in withItems) ...[
+          SectionHeader(
+            title: section.heading,
+            colors: colors,
+            eyebrowText: 'YOUTUBE MUSIC',
+            padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+          ),
+          _Strip(items: section.items, colors: colors),
+          const SizedBox(height: 22),
+        ],
+      ],
+    );
+  }
+}
+
+class _Strip extends StatelessWidget {
+  const _Strip({required this.items, required this.colors});
+
+  final List<FeedItem> items;
+  final SunohColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    const width = 116.0;
+    final shown = items.take(_kPreviewCount).toList();
+    return SizedBox(
+      height: width + 46,
+      child: ListView.separated(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        itemCount: shown.length,
+        separatorBuilder: (_, _) => const SizedBox(width: 12),
+        itemBuilder: (context, i) => _Tile(item: shown[i], colors: colors),
+      ),
+    );
+  }
+}
+
+class _Tile extends StatelessWidget {
+  const _Tile({required this.item, required this.colors});
+
+  final FeedItem item;
+  final SunohColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    const width = 116.0;
+    // Artists read as people, everything else as artwork — the same rule the
+    // home feed follows, so a shelf does not change shape between tabs.
+    final round = item.type == 'artist';
+    return GestureDetector(
+      onTap: () => context.openYtItem(item),
+      behavior: HitTestBehavior.opaque,
+      child: SizedBox(
+        width: width,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (round)
+              ClipOval(
+                child: SunohArt(
+                  id: item.id,
+                  size: width,
+                  radius: 0,
+                  imageUrl: _art(item),
+                ),
+              )
+            else
+              SunohArt(
+                id: item.id,
+                size: width,
+                radius: 10,
+                imageUrl: _art(item),
+              ),
+            const SizedBox(height: 8),
+            Text(
+              item.title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: SunohType.sans(
+                fontSize: 12.5,
+                fontWeight: FontWeight.w500,
+                color: c.fg,
+              ),
+            ),
+            if ((item.subtitle ?? '').isNotEmpty)
+              Text(
+                item.subtitle!,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: SunohType.sans(fontSize: 11, color: c.fgMute),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// The largest artwork the item carries, or null to fall back to the painted
+/// placeholder. YouTube ships several sizes; the biggest is the one that still
+/// looks right on a high-density screen.
+String? _art(FeedItem item) {
+  if (item.image.isEmpty) return null;
+  return item.image.last.link;
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -17,9 +17,11 @@ import '../api/yt_locale.dart';
 import '../audio/storage_stats.dart';
 import '../overlays/language_sheet.dart';
 import '../overlays/yt_locale_sheet.dart';
+import '../overlays/yt_sign_out_sheet.dart';
 import '../providers/app_state_provider.dart';
 import '../providers/languages_provider.dart';
 import '../providers/update_provider.dart';
+import '../providers/yt_auth_provider.dart';
 import '../providers/ytmusic_provider.dart';
 import '../router/router.dart';
 import '../state/app_state.dart';
@@ -112,6 +114,12 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                     'Keep music going by seeding a radio when the queue ends.',
                 value: s.endlessAutoplay,
                 onChange: s.setEndlessAutoplay,
+                colors: c,
+              ),
+              _NavRow(
+                label: 'YouTube account',
+                summary: _ytAccountSummary(ref),
+                onTap: () => _toggleYtAccount(context, ref),
                 colors: c,
               ),
               _NavRow(
@@ -618,20 +626,31 @@ class _NavRow extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
           Text(label, style: SunohType.sans(fontSize: 14, color: c.fgDim)),
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Flexible(
-                child: Text(
-                  summary,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                  style: SunohType.sans(fontSize: 13, color: c.fgMute),
+          // A floor under the gap. The summary is Flexible, so without this it
+          // shrinks until it touches the label rather than ellipsising, and a
+          // long value renders as one run-on string.
+          const SizedBox(width: 16),
+          Flexible(
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Flexible(
+                  child: Text(
+                    summary,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.end,
+                    style: SunohType.sans(fontSize: 13, color: c.fgMute),
+                  ),
                 ),
-              ),
-              const SizedBox(width: 6),
-              Icon(SolarIconsOutline.altArrowRight, size: 16, color: c.fgMute),
-            ],
+                const SizedBox(width: 6),
+                Icon(
+                  SolarIconsOutline.altArrowRight,
+                  size: 16,
+                  color: c.fgMute,
+                ),
+              ],
+            ),
           ),
         ],
       ),
@@ -890,6 +909,36 @@ class _DonationAction extends StatelessWidget {
 /// kicks in). Reads from the languages provider to map slugs → names —
 /// the provider is autoDispose with 24-h keepAlive, so this read is
 /// cheap and won't bounce a refetch.
+/// Who the YouTube feed belongs to. Names the account when there is one, so
+/// there is never any doubt whose recommendations are on the home screen.
+String _ytAccountSummary(WidgetRef ref) {
+  final auth = ref.watch(ytAuthProvider);
+  if (auth.isBusy) return 'Working…';
+  if (!auth.isSignedIn) return 'Sign in';
+  return auth.account.name.isEmpty ? 'Signed in' : auth.account.name;
+}
+
+/// One row, both directions. Signing out is the destructive half, so it asks
+/// first; signing in is not, so it does not.
+Future<void> _toggleYtAccount(BuildContext context, WidgetRef ref) async {
+  final auth = ref.read(ytAuthProvider);
+  final state = ref.read(appStateProvider);
+  if (auth.isBusy) return;
+
+  if (!auth.isSignedIn) {
+    final ok = await auth.signIn();
+    if (!context.mounted) return;
+    state.flashToast(ok ? 'Signed in to YouTube Music' : 'Not signed in');
+    return;
+  }
+
+  final confirmed = await showYtSignOutSheet(context, auth.account.name);
+  if (!confirmed || !context.mounted) return;
+  await auth.signOut();
+  if (!context.mounted) return;
+  state.flashToast('Signed out');
+}
+
 /// "Auto (India)" or "United States" — always says what's in effect, so
 /// the row reads the same whether or not an override is set.
 String _ytRegionSummary(WidgetRef ref, AppState s) {

--- a/lib/widgets/spotify_import_banner.dart
+++ b/lib/widgets/spotify_import_banner.dart
@@ -46,7 +46,7 @@ class SpotifyImportBanner extends ConsumerWidget {
           borderRadius: BorderRadius.circular(14),
           child: DecoratedBox(
             decoration: BoxDecoration(
-              color: const Color(0xFF15151A),
+              color: c.bgSoft,
               border: Border.all(color: c.line, width: 0.5),
               borderRadius: BorderRadius.circular(14),
             ),

--- a/lib/widgets/update_banner.dart
+++ b/lib/widgets/update_banner.dart
@@ -16,7 +16,7 @@ import '../providers/app_state_provider.dart';
 import '../providers/update_provider.dart';
 import '../theme/tokens.dart';
 import 'ui.dart';
-import 'update_dialog.dart';
+import 'update_sheet.dart';
 
 /// Card variant — used inside Settings → About so the same info has a
 /// home if the user dismissed the auto-shown dialog on Home. Designed
@@ -59,7 +59,7 @@ class _UpdateRow extends ConsumerWidget {
       // Re-open the auto-show dialog — keeps Settings as a backstop
       // for the user who dismissed the home dialog with "Later" and
       // came back later to actually update.
-      onTap: () => showUpdateDialog(context, info),
+      onTap: () => showUpdateSheet(context, info),
       child: Container(
         padding: EdgeInsets.symmetric(horizontal: 14, vertical: slim ? 12 : 16),
         decoration: squircleDecoration(

--- a/lib/widgets/update_sheet.dart
+++ b/lib/widgets/update_sheet.dart
@@ -1,8 +1,8 @@
-// "Update available" dialog — replaces the inline UpdateBanner on Home.
+// "Update available" sheet — replaces the inline UpdateBanner on Home.
 //
 // Auto-shown by HomeScreen on the first build where
 // `availableUpdateProvider` yields a non-null UpdateInfo AND the user
-// hasn't dismissed-this-session. The dialog drives a [UpdaterController]
+// hasn't dismissed-this-session. The sheet drives a [UpdaterController]
 // through prepare → downloading → installing, surfacing progress and
 // final hand-off to the OS installer.
 
@@ -16,6 +16,7 @@ import 'package:flutter_riverpod/legacy.dart';
 import 'package:solar_icons/solar_icons.dart';
 
 import '../api/updates.dart';
+import '../overlays/sheet.dart';
 import '../providers/app_state_provider.dart';
 import '../providers/update_provider.dart';
 import '../services/updater.dart';
@@ -23,27 +24,31 @@ import '../theme/tokens.dart';
 import 'ui.dart';
 
 /// Riverpod provider for the singleton updater controller — kept
-/// outside the dialog so the download survives the dialog being
+/// outside the sheet so the download survives the sheet being
 /// dismissed and re-opened (e.g. user hits Later by accident).
 final updaterControllerProvider = ChangeNotifierProvider<UpdaterController>(
   (ref) => UpdaterController(),
 );
 
-/// Show the update dialog. Idempotent — pops at most once per call.
-/// Returns when the user dismisses (Later / Install / × / errored
-/// fallback). Doesn't block any subsequent code; the actual update
-/// progress lives on the controller and the dialog re-attaches if
-/// re-shown.
-Future<void> showUpdateDialog(BuildContext context, UpdateInfo info) {
-  return showDialog<void>(
-    context: context,
-    barrierDismissible: true,
-    builder: (_) => _UpdateDialog(info: info),
+/// Show the update sheet. Idempotent — pops at most once per call.
+///
+/// A sheet rather than the dialog this used to be: the buttons land under the
+/// thumb instead of at the top of a tall phone, a long changelog scrolls
+/// inside it rather than turning the whole thing into a floating scroll box,
+/// and it shares its chrome with every other sheet in the app instead of
+/// carrying its own radius, padding and hardcoded background.
+///
+/// Returns when the user dismisses it. The download lives on the controller,
+/// so dismissing mid-download does not cancel it and re-opening re-attaches.
+Future<void> showUpdateSheet(BuildContext context, UpdateInfo info) {
+  return showSunohSheet<void>(
+    context,
+    builder: (_) => _UpdateSheet(info: info),
   );
 }
 
-class _UpdateDialog extends ConsumerWidget {
-  const _UpdateDialog({required this.info});
+class _UpdateSheet extends ConsumerWidget {
+  const _UpdateSheet({required this.info});
   final UpdateInfo info;
 
   @override
@@ -52,98 +57,60 @@ class _UpdateDialog extends ConsumerWidget {
     final c = s.colors;
     final accent = s.resolvedAccent;
     final updater = ref.watch(updaterControllerProvider);
-    return Dialog(
-      backgroundColor: Colors.transparent,
-      insetPadding: const EdgeInsets.symmetric(horizontal: 24),
-      child: Container(
-        decoration: squircleDecoration(
-          radius: 20,
-          color: const Color(0xFF15151A),
-          borderColor: c.line,
-        ),
-        padding: const EdgeInsets.fromLTRB(20, 22, 20, 18),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            // Header — accent medallion + title + version pill.
-            Row(
-              children: [
-                Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: accent.withValues(alpha: 0.18),
-                    shape: BoxShape.circle,
-                  ),
-                  alignment: Alignment.center,
-                  child: Icon(
-                    SolarIconsBold.downloadMinimalistic,
-                    size: 20,
-                    color: accent,
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        'Update available',
-                        style: SunohType.heading(
-                          fontSize: 17,
-                          color: c.fg,
-                          letterSpacing: -0.2,
-                        ),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        'v${info.version}',
-                        style: SunohType.sans(fontSize: 12, color: c.fgMute),
-                      ),
-                    ],
-                  ),
-                ),
-                if (updater.stage == UpdateStage.idle ||
-                    updater.stage == UpdateStage.failed)
-                  IconButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                    icon: Icon(
-                      SolarIconsOutline.closeCircle,
-                      size: 20,
-                      color: c.fgDim,
-                    ),
-                    splashRadius: 18,
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints(),
-                  ),
-              ],
-            ),
-            if ((info.notes ?? '').isNotEmpty) ...[
-              const SizedBox(height: 14),
-              Container(
+    final notes = info.notes ?? '';
+    // Closing mid-download would strand a running job behind a sheet with no
+    // way back to it, so the way out is only offered when nothing is running.
+    final canClose =
+        updater.stage == UpdateStage.idle ||
+        updater.stage == UpdateStage.failed;
+
+    return SunohSheet(
+      icon: SolarIconsBold.downloadMinimalistic,
+      title: 'Update available',
+      subtitle: 'Version ${info.version}',
+      trailing: canClose
+          ? IconButton(
+              onPressed: () => Navigator.of(context).pop(),
+              icon: Icon(
+                SolarIconsOutline.closeCircle,
+                size: 20,
+                color: c.fgDim,
+              ),
+              splashRadius: 18,
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(),
+            )
+          : null,
+      actions: _Body(info: info, updater: updater, accent: accent, colors: c),
+      child: notes.isEmpty
+          ? const SizedBox.shrink()
+          : Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 4),
+              child: Container(
+                width: double.infinity,
                 padding: const EdgeInsets.fromLTRB(14, 12, 14, 12),
                 decoration: squircleDecoration(
-                  radius: 12,
+                  radius: 14,
                   color: c.surface,
                   borderColor: c.line,
                 ),
-                child: Text(
-                  info.notes!,
-                  style: SunohType.sans(
-                    fontSize: 13,
-                    color: c.fg,
-                    height: 1.45,
-                  ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    eyebrow("WHAT'S NEW", c.fgMute),
+                    const SizedBox(height: 8),
+                    Text(
+                      notes,
+                      style: SunohType.sans(
+                        fontSize: 13,
+                        color: c.fgDim,
+                        height: 1.5,
+                      ),
+                    ),
+                  ],
                 ),
               ),
-            ],
-            const SizedBox(height: 16),
-            _Body(info: info, updater: updater, accent: accent, colors: c),
-          ],
-        ),
-      ),
+            ),
     );
   }
 }

--- a/test/sync_scope_test.dart
+++ b/test/sync_scope_test.dart
@@ -1,0 +1,75 @@
+// What library sync is allowed to carry off this device.
+//
+// Sync writes an encrypted file into a folder a cloud client uploads. That is
+// the right home for playlists and preferences and a catastrophic one for a
+// credential, so the boundary is pinned here rather than left to whoever edits
+// the allow-list next.
+//
+// These tests fail loudly if a future key slips in. That is the point: the
+// mistake they guard against is one careless line, and it would not look
+// wrong.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sunoh/audio/settings_store.dart';
+
+void main() {
+  group('sync allow-list', () {
+    test('carries only appearance and playback preferences', () {
+      // Namespaces, not a list of keys — a new appearance setting should not
+      // have to come back here, and a new namespace should.
+      for (final key in SyncSettings.syncableKeys) {
+        expect(
+          key.startsWith('appearance.') || key.startsWith('playback.'),
+          isTrue,
+          reason: '$key is outside the namespaces sync is allowed to carry',
+        );
+      }
+    });
+
+    test('carries nothing to do with a signed-in account', () {
+      // The YouTube session is a Google cookie: whoever holds it can act as
+      // the user. It lives in Keystore-encrypted storage on the device and
+      // must never enter the settings box that sync uploads.
+      const forbidden = [
+        'cookie',
+        'auth',
+        'account',
+        'session',
+        'token',
+        'sapisid',
+        'credential',
+        'password',
+        'visitor',
+      ];
+      for (final key in SyncSettings.syncableKeys) {
+        for (final word in forbidden) {
+          expect(
+            key.toLowerCase().contains(word),
+            isFalse,
+            reason: '$key looks like a credential and must not sync',
+          );
+        }
+      }
+    });
+
+    test('carries nothing describing this particular device', () {
+      // Folder choices, download paths and the sync configuration itself are
+      // meaningless or harmful on another phone.
+      const deviceOnly = ['local.', 'sync.', 'downloads.', 'search.'];
+      for (final key in SyncSettings.syncableKeys) {
+        for (final prefix in deviceOnly) {
+          expect(
+            key.startsWith(prefix),
+            isFalse,
+            reason: '$key is per-device and must not sync',
+          );
+        }
+      }
+    });
+
+    test('the allow-list is not empty', () {
+      // Otherwise the tests above pass by saying nothing.
+      expect(SyncSettings.syncableKeys, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
Optional YouTube Music sign-in, so the home feed and library are yours rather than generic. Signed out, every request is byte-for-byte what it was before this existed.

Verified end to end on a real device: signed in, account name resolved, **Quick picks / Covers and remixes / Listen together** now render on Home → Music.

## How sign-in works

Google publishes no OAuth scope giving a third party access to YouTube Music, so this goes through Google's own sign-in page in a web view — the same thing Metrolist and InnerTune do. The password is typed into Google's page over Google's TLS; this app never sees it. What comes back is the session cookie a browser would have held anyway.

**That cookie is treated as a credential, not a setting:**

- Encrypted at rest with a key in the **Android Keystore**, so it cannot be lifted from an `adb backup` or a copied `shared_prefs` file.
- In its own store, **never the Hive settings box that library sync uploads** to a folder a cloud client watches. Keeping it elsewhere means it cannot be added to the sync allow-list by accident — and `test/sync_scope_test.dart` now fails if anything credential-shaped ever appears there.
- **Never crossed to Dart.** Dart asks the native side for one request's headers and forgets them; the SAPISIDHASH covers a timestamp, so a header set is good for exactly one call.
- Never logged, and never sent to `api.sunoh.online`. Putting user session cookies on our server would turn a no-account app into a credential store with a breach liability.

No new Gradle dependency: `javax.crypto` and the platform Keystore already do all of it, same reasoning as `SyncBridge`.

## Why the personalized feed needed no new code

Authentication is applied in `_post`, the single funnel every InnerTube call goes through, rather than per endpoint. `home()` already browsed `FEmusic_home`, so the request that returns generic charts signed out returns Quick picks signed in. A caller that had to remember to ask for auth would eventually forget on one path and serve a signed-in user someone else's home page.

## Three things this cost, worth writing down

- **Spoofing a desktop Chrome user agent *causes* Google's "this browser or app may not be secure" block rather than avoiding it.** Google checks the claim against the JS environment, and a desktop string on a WebView reads as evasion. The stock agent goes straight through — Metrolist doesn't override it either.
- **`onPageFinished` fires long before a single-page app has populated `ytcfg`.** A one-shot read finds nothing and never runs again, so a completed sign-in went undetected. It polls now, and no longer requires `visitorData` to declare success — the cookie and the signature are what authenticate.
- **`X-Goog-PageId` is not where a `dataSyncId` goes.** That header names a channel to *act as*, so YouTube answered as an identity that does not exist: an account menu with no account in it and a home feed with nothing personal on it, while every header looked present and correct. `innertubex` does not send it. This one bug hid all of the above.

Renderer paths are now searched by name rather than hardcoded — the account name moved twice during this work. The tree reshuffles; the renderer names do not.

## Sheets

The sign-out confirmation needed a sheet and there was nothing to build it on, so the shape got extracted. Sheets had drifted: each re-declared its own radius, padding and handle, and **eleven hardcoded `Color(0xFF15151A)`** — a raw value outside `tokens.dart`, and a dark one, so **every sheet stayed dark in light mode**. `bgSoft` is the token documented for that surface.

Two bugs fell out of building it:

- Sheets were pushed onto the shell's **branch navigator**, which paints *under* the mini player and bottom nav. A sheet tall enough to reach them had its buttons behind the player, where they cannot be tapped. They go on the root navigator now.
- `_NavRow` had no minimum gap between label and value, so a long value shrank until the two touched and rendered as one run-on string instead of ellipsising.

The update dialog becomes a sheet on that shell — buttons under the thumb rather than at the top of a tall phone, changelog scrolling inside it rather than the whole dialog becoming a floating scroll box. All four download stages unchanged.

## Housekeeping

`ytmusic_api.dart` is split 1076 → 665 along the seam between transport and renderer parsing, so this lands in its own files rather than on top of an already over-limit one.

README and the store listing now say *"no account of ours, optional YouTube sign-in kept on your phone"* instead of *"no sign-in, ever"*, which this would otherwise have made false the day it shipped.

## Testing

173 tests pass; the analyzer reports nothing new (8 pre-existing warnings).

**Not verified visually:** the update sheet's four download stages. It shares the shell and compiles clean, but showing it needs an actual available update, so I have not watched a real download run through it.
