### PR TITLE
Move every endpoint out of source and into a gitignored env.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ ios/.symlinks/
 macos/Pods/
 macos/.symlinks/
 **/Podfile.lock
+
+# Build-time endpoint configuration. The values this build talks to are not
+# committed; env.example.json documents the shape. See lib/config/env.dart.
+/env.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,12 +19,19 @@ web and desktop builds cannot resolve YouTube streams.
 
 ```sh
 flutter pub get
-flutter run                                  # Android device or emulator
+cp env.example.json env.json                 # then fill it in — see below
+flutter run --dart-define-from-file=env.json # Android device or emulator
 flutter analyze                              # see "Before finishing" below
 dart fix --apply                             # mechanical lint fixes
 dart format lib/path/you/touched.dart        # NOT `dart format .` — see below
-flutter build apk --split-per-abi --release
+flutter build apk --split-per-abi --release --dart-define-from-file=env.json
 ```
+
+Endpoints are **not** hardcoded: they come from `env.json` at compile time
+(`lib/config/env.dart`), and `env.json` is gitignored so a public repo carries
+no private base URL. A build without it still runs — the on-device library and
+the YouTube tier need nothing from sunoh-api — but the catalog screens render
+their error state. `scripts/release.sh` refuses to build without it.
 
 `flutter test` runs 30 tests covering the Android Auto surface
 (`auto_browse`, `auto_media_id`). The rest of the app is uncovered — see

--- a/README.md
+++ b/README.md
@@ -154,14 +154,33 @@ UPI VPA: `afkcodes@ybl` — both are also in the app under
 
 ```sh
 flutter pub get
-flutter run
+cp env.example.json env.json   # then fill in the endpoints
+flutter run --dart-define-from-file=env.json
 ```
 
 Release builds, split per ABI:
 
 ```sh
-flutter build apk --split-per-abi --release
+flutter build apk --split-per-abi --release --dart-define-from-file=env.json
 ```
+
+### Endpoints
+
+Every endpoint the app talks to lives in `env.json`, which is **gitignored** —
+this repository carries no base URL of its own. `env.example.json` documents
+the shape; the third-party ones (LRCLIB, SponsorBlock, InnerTube) are filled in
+there because they are public, and the sunoh-specific ones are blank.
+
+A build without `env.json` still runs. The on-device library and the YouTube
+tier need nothing from sunoh-api, so they keep working; the catalog screens
+render their normal error state. `scripts/release.sh` refuses to build a
+release without it.
+
+This is configuration, not secrecy. A compile-time define is baked into the
+APK, so anyone with the file can read every URL out of it — and anyone running
+the app can watch them go past in a proxy. The point is that a public
+repository does not carry a private backend URL, and that a fork or a
+self-hoster can repoint the app without editing code.
 
 Requires the Flutter SDK (Dart `^3.11.5`) and the Android SDK. The YouTube
 extraction path and the on-device library are native Kotlin under

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -22,6 +22,23 @@ if (keystorePropertiesFile.exists()) {
     keystoreProperties.load(FileInputStream(keystorePropertiesFile))
 }
 
+// The web host for App Links comes from the same env.json the Dart side reads,
+// so there is one place to change it and neither copy can drift. Parsed here
+// rather than duplicated into gradle.properties for that reason.
+//
+// Absent, it falls back to a host that resolves nothing. An unconfigured build
+// must not register itself as a handler for links it cannot serve — that would
+// put a stranger's build in the "open with" sheet for someone else's domain.
+val sunohWebHost: String = run {
+    val envFile = rootProject.file("../env.json")
+    if (!envFile.exists()) return@run "invalid.localhost"
+    val raw = groovy.json.JsonSlurper().parse(envFile) as? Map<*, *>
+        ?: return@run "invalid.localhost"
+    val web = raw["SUNOH_WEB_BASE"]?.toString().orEmpty()
+    if (web.isBlank()) "invalid.localhost"
+    else web.substringAfter("://").substringBefore("/").ifBlank { "invalid.localhost" }
+}
+
 android {
     // Same applicationId as the RN sunoh app — same keystore (see
     // [[sunoh-android-signing]]) means installing this Flutter build over
@@ -40,6 +57,7 @@ android {
 
     defaultConfig {
         applicationId = "codes.afk.sunoh"
+        manifestPlaceholders["sunohWebHost"] = sunohWebHost
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         // Bumped from flutter default (21) to 24 — mpv_audio_kit (libmpv)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -88,16 +88,22 @@
                 <category android:name="android.intent.category.BROWSABLE"/>
                 <data android:scheme="sunoh"/>
             </intent-filter>
-            <!-- App Links: https://sunoh.online/* — autoVerify=true so
-                 Android skips the chooser when the assetlinks.json at
-                 https://sunoh.online/.well-known/assetlinks.json is reachable
-                 and lists this package + signing fingerprint. Until then the
-                 user sees a "open with…" sheet but the wiring still works. -->
+            <!-- App Links for the web host, which comes from env.json via a
+                 manifest placeholder rather than being written here — the
+                 same reason the Dart endpoints do. autoVerify=true so Android
+                 skips the chooser when that host serves a
+                 /.well-known/assetlinks.json listing this package and signing
+                 fingerprint. Until then the user sees an "open with…" sheet
+                 but the wiring still works.
+
+                 A build with no host configured falls back to a placeholder
+                 that resolves nothing, which is correct: an unconfigured
+                 build should not claim links it cannot serve. -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.BROWSABLE"/>
-                <data android:scheme="https" android:host="sunoh.online"/>
+                <data android:scheme="https" android:host="${sunohWebHost}"/>
             </intent-filter>
         </activity>
         <!-- Android Auto. Points at res/xml/automotive_app_desc.xml, which

--- a/env.example.json
+++ b/env.example.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Copy to env.json and fill in. env.json is gitignored. Build with: flutter build apk --release --dart-define-from-file=env.json",
+
+  "SUNOH_API_BASE": "",
+  "SUNOH_WEB_BASE": "",
+  "SUNOH_UPDATE_MANIFEST": "",
+
+  "LRCLIB_BASE": "https://lrclib.net",
+  "SPONSORBLOCK_BASE": "https://sponsor.ajay.app/api/skipSegments",
+  "GEOIP_BASE": "https://ipwho.is/",
+  "YTMUSIC_BASE": "https://music.youtube.com/youtubei/v1"
+}

--- a/lib/api/client.dart
+++ b/lib/api/client.dart
@@ -3,16 +3,15 @@
 
 import 'package:dio/dio.dart';
 
-class SunohApiEnv {
-  static const prod = 'https://api.sunoh.online';
-  // Android emulator → 10.0.2.2 maps to the host machine's localhost.
-  // On iOS simulator: use 'http://localhost:3600'.
-  // On a real device on the same Wi-Fi: use 'http://<host-LAN-ip>:3600'.
-  static const localEmulator = 'http://10.0.2.2:3600';
-  static const localHost = 'http://localhost:3600';
+import '../config/env.dart';
 
-  // Active base URL. Change this single line when switching environments.
-  static const baseUrl = prod;
+class SunohApiEnv {
+  /// Set by `--dart-define-from-file=env.json` — see lib/config/env.dart.
+  ///
+  /// Pointing at a local server is a matter of changing env.json rather than
+  /// editing this file: `http://10.0.2.2:3600` for an Android emulator (which
+  /// maps to the host's localhost), or the host's LAN IP for a real device.
+  static const baseUrl = Env.apiBase;
 }
 
 Dio buildSunohDio() {

--- a/lib/api/lrclib.dart
+++ b/lib/api/lrclib.dart
@@ -22,20 +22,22 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
+import '../config/env.dart';
+
 class LrcLibClient {
   LrcLibClient({Dio? dio})
     : _dio =
           dio ??
           Dio(
             BaseOptions(
-              baseUrl: 'https://lrclib.net',
+              baseUrl: Env.lrclibBase,
               connectTimeout: const Duration(seconds: 6),
               receiveTimeout: const Duration(seconds: 8),
               headers: const {
                 // LRCLIB asks integrators to identify themselves so they can
                 // troubleshoot traffic spikes. Polite and they recommend it
                 // in the docs.
-                'User-Agent': 'sunoh/1.0 (https://sunoh.online)',
+                'User-Agent': 'sunoh/1.0 (${Env.webBase})',
                 'Accept': 'application/json',
               },
               responseType: ResponseType.json,

--- a/lib/api/sponsorblock.dart
+++ b/lib/api/sponsorblock.dart
@@ -14,6 +14,8 @@ import 'dart:convert';
 import 'package:crypto/crypto.dart';
 import 'package:dio/dio.dart';
 
+import '../config/env.dart';
+
 /// A segment worth skipping.
 class SkipSegment {
   const SkipSegment({
@@ -56,7 +58,7 @@ class SponsorBlockClient {
   SponsorBlockClient(this._dio);
   final Dio _dio;
 
-  static const _kBase = 'https://sponsor.ajay.app/api/skipSegments';
+  static const _kBase = Env.sponsorBlockBase;
 
   /// Segments for [videoId], or an empty list when there are none (by far
   /// the common case) or the lookup fails. Never throws: missing segment

--- a/lib/api/updates.dart
+++ b/lib/api/updates.dart
@@ -22,8 +22,9 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
-const String _kUpdatesUrl =
-    'https://sunoh.online/.well-known/sunoh-updates.json';
+import '../config/env.dart';
+
+const String _kUpdatesUrl = Env.updateManifest;
 
 class UpdateInfo {
   const UpdateInfo({

--- a/lib/api/yt_locale.dart
+++ b/lib/api/yt_locale.dart
@@ -27,6 +27,8 @@
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 
+import '../config/env.dart';
+
 /// A resolved (region, language) pair plus where it came from, so the UI
 /// can show "Auto (India)" rather than pretending the user chose it.
 @immutable
@@ -175,7 +177,7 @@ class YtLocaleResolver {
     if (_freshCachedCountry() != null) return _cachedCountry;
     try {
       final res = await _dio.get<Map<String, dynamic>>(
-        'https://ipwho.is/',
+        Env.geoIpBase,
         options: Options(
           responseType: ResponseType.json,
           receiveTimeout: const Duration(seconds: 6),

--- a/lib/api/ytmusic_api.dart
+++ b/lib/api/ytmusic_api.dart
@@ -15,6 +15,7 @@
 
 import 'package:dio/dio.dart';
 
+import '../config/env.dart';
 import 'dto.dart';
 import 'yt_auth_channel.dart';
 import 'yt_locale.dart';
@@ -32,7 +33,7 @@ typedef AuthHeaders = Future<Map<String, String>> Function();
 /// The YouTube Music web client. No API key or auth needed for search/browse.
 const _kClientName = 'WEB_REMIX';
 const _kClientVersion = '1.20260101.01.00';
-const _kBase = 'https://music.youtube.com/youtubei/v1';
+const _kBase = Env.ytMusicBase;
 
 /// `params` filters pinning search to one result type. Opaque
 /// protobuf-derived values from the web client.
@@ -148,6 +149,9 @@ class YtMusicApi {
       'Content-Type': 'application/json',
       'X-Youtube-Client-Name': '67',
       'X-Youtube-Client-Version': _kClientVersion,
+      // Not configuration: InnerTube validates the origin, and the SAPISIDHASH
+      // is computed over this exact string on the native side. It is part of
+      // the request contract rather than something a build points elsewhere.
       'Origin': 'https://music.youtube.com',
       ...auth,
     },

--- a/lib/config/env.dart
+++ b/lib/config/env.dart
@@ -1,0 +1,57 @@
+// Every endpoint and third-party constant the app is built against.
+//
+// Nothing here is hardcoded in source. Values arrive at compile time from
+// `--dart-define-from-file=env.json`, and `env.json` is gitignored — so the
+// backend this build talks to is not committed to a public repository. See
+// `env.example.json` for the shape and `README.md` for how to build.
+//
+// **This is configuration, not secrecy.** A `--dart-define` value is compiled
+// into the APK as a constant. Anyone holding the APK can read every URL here
+// with `strings`, and anyone running the app can read them off the wire with a
+// proxy. That is unavoidable — the app has to know where to connect. What this
+// buys is that a public repository does not carry a private base URL, and that
+// a fork or a self-hoster can point the app somewhere else without editing
+// code.
+//
+// A missing value is empty rather than a build failure. The app is built by
+// contributors who have no reason to hold a production endpoint, and it
+// degrades honestly: requests against an empty base fail, and the screens that
+// need them already render their own error state. The on-device library and
+// the YouTube tier keep working, because neither goes through sunoh-api.
+class Env {
+  const Env._();
+
+  /// sunoh-api: the catalog behind Home, Search and every detail screen.
+  static const apiBase = String.fromEnvironment('SUNOH_API_BASE');
+
+  /// The public website, used to build shareable links.
+  static const webBase = String.fromEnvironment('SUNOH_WEB_BASE');
+
+  /// Where the in-app updater looks for the release manifest.
+  static const updateManifest = String.fromEnvironment('SUNOH_UPDATE_MANIFEST');
+
+  /// Community lyrics. A public API, kept configurable so a fork can point at
+  /// a mirror or its own instance.
+  static const lrclibBase = String.fromEnvironment('LRCLIB_BASE');
+
+  /// SponsorBlock segment lookup. Only ever sent a 4-character hash prefix.
+  static const sponsorBlockBase = String.fromEnvironment('SPONSORBLOCK_BASE');
+
+  /// Coarse IP geolocation, used once to pick a default YouTube region.
+  static const geoIpBase = String.fromEnvironment('GEOIP_BASE');
+
+  /// YouTube's InnerTube API root.
+  static const ytMusicBase = String.fromEnvironment('YTMUSIC_BASE');
+
+  /// Names of the values this build is missing, for a one-line startup log.
+  /// Not fatal — see the note above about contributor builds.
+  static List<String> get missing => {
+    'SUNOH_API_BASE': apiBase,
+    'SUNOH_WEB_BASE': webBase,
+    'SUNOH_UPDATE_MANIFEST': updateManifest,
+    'LRCLIB_BASE': lrclibBase,
+    'SPONSORBLOCK_BASE': sponsorBlockBase,
+    'GEOIP_BASE': geoIpBase,
+    'YTMUSIC_BASE': ytMusicBase,
+  }.entries.where((e) => e.value.isEmpty).map((e) => e.key).toList();
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ import 'audio/playback_state_store.dart';
 import 'audio/settings_store.dart';
 import 'audio/sponsorblock_skipper.dart';
 import 'cast/cast_service.dart';
+import 'config/env.dart';
 import 'providers/app_state_provider.dart';
 import 'providers/downloads_provider.dart';
 import 'providers/ytmusic_provider.dart';
@@ -131,6 +132,16 @@ class _LooseClampingScrollPhysics extends ClampingScrollPhysics {
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+
+  // Say so once, loudly, rather than letting the catalog screens fail with a
+  // generic network error that looks like the backend is down.
+  if (Env.missing.isNotEmpty) {
+    debugPrint(
+      '[env] built without ${Env.missing.join(', ')} — '
+      'copy env.example.json to env.json and pass '
+      '--dart-define-from-file=env.json',
+    );
+  }
 
   // Local persistence (queue + future library/history/settings boxes).
   await Hive.initFlutter();

--- a/lib/share/share_link.dart
+++ b/lib/share/share_link.dart
@@ -15,7 +15,9 @@
 import 'package:flutter/foundation.dart';
 import 'package:share_plus/share_plus.dart';
 
-const String _kBaseUrl = 'https://sunoh.online';
+import '../config/env.dart';
+
+const String _kBaseUrl = Env.webBase;
 
 /// Build the canonical share URL for a piece of content.
 ///

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -295,15 +295,24 @@ PY
 fi
 
 # ── Build APK(s) ───────────────────────────────────────────────────────────
+# Endpoints come from env.json (gitignored) rather than from source. A release
+# built without it would ship pointing at nothing, so this is fatal here even
+# though a contributor's debug build degrades quietly.
+ENV_FILE="env.json"
+if [[ ! -f $ENV_FILE ]]; then
+  die "$ENV_FILE not found — copy env.example.json and fill it in"
+fi
+DART_DEFINE="--dart-define-from-file=$ENV_FILE"
+
 log "running flutter build apk --release$([[ $SPLIT_APKS == 1 ]] && echo ' --split-per-abi')"
 if (( SPLIT_APKS )); then
-  run "flutter build apk --release --split-per-abi"
+  run "flutter build apk --release --split-per-abi $DART_DEFINE"
   # The universal APK ships alongside the splits, not instead of them.
   # Third-party repositories that mirror GitHub releases (IzzyOnDroid) take one
   # artifact per version and cannot choose between three ABIs; Obtainium can,
   # but falls back to this for any ABI we did not split for. Splits stay first
   # in the list so they remain the obvious download for a human.
-  run "flutter build apk --release"
+  run "flutter build apk --release $DART_DEFINE"
   APKS=(
     "build/app/outputs/flutter-apk/app-arm64-v8a-release.apk"
     "build/app/outputs/flutter-apk/app-armeabi-v7a-release.apk"
@@ -311,7 +320,7 @@ if (( SPLIT_APKS )); then
     "build/app/outputs/flutter-apk/app-release.apk"
   )
 else
-  run "flutter build apk --release"
+  run "flutter build apk --release $DART_DEFINE"
   APKS=( "build/app/outputs/flutter-apk/app-release.apk" )
 fi
 


### PR DESCRIPTION
The backend base URL was a constant in lib/api/client.dart, the website was one in share_link.dart and updates.dart, and the third-party APIs were scattered across five more files. All of them now come from `--dart-define-from-file=env.json` via lib/config/env.dart, and env.json is gitignored. env.example.json documents the shape: the public third-party endpoints are filled in there, the sunoh-specific ones are blank.

**This is configuration, not secrecy, and the code says so.** A dart-define is compiled into the APK as a constant, so anyone holding the file can read every URL out of it with `strings`, and anyone running the app can watch them go past in a proxy. That is unavoidable — the app has to know where to connect. What it buys is that a public repository carries no private base URL, and that a fork or a self-hoster can repoint the app without editing code.

A build without env.json still compiles and runs, verified. Contributors have no reason to hold a production endpoint, and the app degrades honestly: the on-device library and the YouTube tier need nothing from sunoh-api and keep working, while the catalog screens render the error state they already had. main() logs the missing names once at startup so this reads as "unconfigured build" rather than "backend is down". scripts/release.sh refuses outright, because a release built pointing at nothing is not worth publishing.

Two things stay hardcoded, deliberately:

  - The PO token's GOOGLE_API_KEY and REQUEST_KEY. Those are YouTube's own public web-client constants — the identical values are in NewPipe, yt-dlp and Metrolist, and in youtube.com's page source. They are not ours and not secret, and enving them would add a build-time footgun for no gain.
  - InnerTube's Origin header. The SAPISIDHASH is computed over that exact string, so it is part of the request contract rather than something a build points elsewhere.