### PR TITLE
Page the YouTube home feed, and stop rebuilding all of it on every theme change

### DIFF
--- a/lib/api/ytmusic_api.dart
+++ b/lib/api/ytmusic_api.dart
@@ -14,6 +14,7 @@
 // upstream should cost us a missing row, not an exception.
 
 import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
 
 import '../config/env.dart';
 import 'dto.dart';
@@ -118,6 +119,12 @@ class YtArtistDetail {
   bool get hasRadio =>
       (radioPlaylistId ?? '').isNotEmpty && (radioVideoId ?? '').isNotEmpty;
 }
+
+/// How far past the first page of the personalized home feed to read.
+///
+/// Four is enough to reach the rows a signed-in account actually recognises as
+/// theirs without turning one home render into a dozen requests.
+const int _kHomeExtraPages = 4;
 
 class YtMusicApi {
   YtMusicApi(this._dio, {this.locale = YtLocale.fallback, AuthHeaders? auth})
@@ -267,7 +274,10 @@ class YtMusicApi {
   /// than failing the feed.
   Future<List<HomeSection>> home() async {
     final pages = await Future.wait([
-      _browseSections('FEmusic_home'),
+      // Only the personalized page is paged. The editorial ones below are
+      // fixed shelves that do not grow with scrolling, so a continuation
+      // would cost a round trip to learn there is nothing more.
+      _browseSections('FEmusic_home', extraPages: _kHomeExtraPages),
       _browseSections('FEmusic_explore'),
       _browseSections('FEmusic_charts'),
       _browseSections('FEmusic_new_releases'),
@@ -288,11 +298,44 @@ class YtMusicApi {
     return out;
   }
 
-  Future<List<HomeSection>> _browseSections(String browseId) async {
+  /// One browse page, plus up to [extraPages] continuations.
+  ///
+  /// YouTube Music serves its home feed a few shelves at a time and the web
+  /// client fetches the rest as the page is scrolled. Reading only the first
+  /// response is why this returned three rows where music.youtube.com shows
+  /// thirty.
+  ///
+  /// Paging is capped rather than exhaustive. The feed is effectively endless,
+  /// each page is a network round trip, and rows nobody scrolls to cost the
+  /// same as rows they do. A page that fails ends the walk and keeps what came
+  /// before it, so a flaky continuation costs the tail of the feed rather than
+  /// the whole thing.
+  Future<List<HomeSection>> _browseSections(
+    String browseId, {
+    int extraPages = 0,
+  }) async {
     try {
       final body = await _post('browse', {..._context, 'browseId': browseId});
       if (body == null) return const [];
-      return _carouselSections(_singleColumnShelves(body));
+      final sections = [..._carouselSections(_singleColumnShelves(body))];
+
+      var token = extraPages > 0 ? _continuationOf(body) : null;
+      for (var page = 0; page < extraPages && token != null; page++) {
+        final next = await _post('browse', {
+          ..._context,
+          'continuation': token,
+        });
+        if (next == null) break;
+        final shelves = _continuationShelves(next);
+        if (shelves.isEmpty) break;
+        sections.addAll(_carouselSections(shelves));
+        token = _continuationOf(next);
+      }
+      debugPrint(
+        '[ytmusic] $browseId: ${sections.length} sections '
+        'over ${extraPages > 0 ? 'up to ${extraPages + 1}' : '1'} page(s)',
+      );
+      return sections;
     } catch (_) {
       return const [];
     }

--- a/lib/api/ytmusic_renderers.dart
+++ b/lib/api/ytmusic_renderers.dart
@@ -423,3 +423,73 @@ Object? _dig(Map<String, dynamic>? node, List<String> path) {
   }
   return cur;
 }
+
+/// The token for the next page of a browse response, or null at the end.
+///
+/// YouTube Music serves its home feed a few shelves at a time and the web
+/// client fetches the rest as you scroll, which is why reading only the first
+/// response gets three rows where the website shows thirty.
+///
+/// Two shapes, because InnerTube is mid-migration and a given response can use
+/// either: the older `continuations[].nextContinuationData`, and the newer
+/// `continuationItemRenderer` that arrives as the last entry in `contents`.
+String? _continuationOf(Map<String, dynamic> body) {
+  // Legacy: continuations[].nextContinuationData.continuation
+  for (final node in _deepList(body, 'continuations')) {
+    final token = _dig(_asMap(node), ['nextContinuationData', 'continuation']);
+    if (token is String && token.isNotEmpty) return token;
+  }
+  // Current: a continuationItemRenderer at the end of the contents.
+  final item = _findRenderer(body, 'continuationItemRenderer');
+  final token = _dig(item, [
+    'continuationEndpoint',
+    'continuationCommand',
+    'token',
+  ]);
+  return token is String && token.isNotEmpty ? token : null;
+}
+
+/// Shelves out of a continuation response, which nests them differently from
+/// the first page.
+List<Map<String, dynamic>> _continuationShelves(Map<String, dynamic> body) {
+  final out = <Map<String, dynamic>>[];
+  for (final key in const [
+    ['continuationContents', 'sectionListContinuation', 'contents'],
+    ['continuationContents', 'musicShelfContinuation', 'contents'],
+  ]) {
+    for (final raw in _asList(_dig(body, key))) {
+      final m = _asMap(raw);
+      if (m != null) out.add(m);
+    }
+  }
+  // Newer responses append through an action rather than a continuation body.
+  for (final action in _asList(body['onResponseReceivedActions'])) {
+    for (final raw in _asList(
+      _dig(_asMap(action), [
+        'appendContinuationItemsAction',
+        'continuationItems',
+      ]),
+    )) {
+      final m = _asMap(raw);
+      if (m != null) out.add(m);
+    }
+  }
+  return out;
+}
+
+/// Every value stored under [key] anywhere in the tree, flattened.
+List<Object?> _deepList(Object? node, String key, [int depth = 0]) {
+  if (depth > 8) return const [];
+  final out = <Object?>[];
+  if (node is Map) {
+    for (final entry in node.entries) {
+      if (entry.key == key) out.addAll(_asList(entry.value));
+      out.addAll(_deepList(entry.value, key, depth + 1));
+    }
+  } else if (node is List) {
+    for (final value in node) {
+      out.addAll(_deepList(value, key, depth + 1));
+    }
+  }
+  return out;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -133,6 +133,40 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
 
+  // Flutter's default decoded-image budget is 100 MiB, and this app blows
+  // through it on one screen. A home feed of ~20 shelves is a couple of
+  // hundred tiles, and a tile decoded at its 384 px cache tier costs
+  // 384*384*4 = 590 KB — call it 118 MB before a detail screen's 1200 px hero
+  // adds another 5.8 MB of its own.
+  //
+  // Past the limit Flutter evicts, so opening an album and coming back found
+  // the feed's bitmaps gone and re-decoded every one of them from disk. That
+  // is the "all the images re-render when I go back" symptom: not widget
+  // churn — SunohArt already handles that — but a cache too small to hold one
+  // screen's worth of art.
+  //
+  // Flutter's default is 100 MiB, which was marginal here for a reason worth
+  // recording: home tiles were decoding at the 720 rung and costing 2 MB each
+  // (see the tier ladder in widgets/album_art.dart), so the default held only
+  // about 48 images — less than one screen of feed plus a detail page.
+  //
+  // With the tier fixed a tile is under 1 MB, so this holds roughly 190. That
+  // is comfortably more than the working set: the sections on screen, plus
+  // whatever a detail screen decodes on top.
+  //
+  // Deliberately not larger. It was briefly 320 MiB while chasing a flicker on
+  // back-navigation, and measurement showed that was the wrong suspect — the
+  // cache sits pinned at whatever ceiling it is given, evicting constantly,
+  // and the flicker was an eager rebuild of the whole feed rather than a cache
+  // miss. Hundreds of MB of native bitmap buys nothing here and is how an app
+  // gets killed in the background on a mid-range phone.
+  //
+  // A ceiling, not an allocation: only what has actually been decoded is held,
+  // least-recently-used goes first, and Flutter drops all of it under memory
+  // pressure.
+  PaintingBinding.instance.imageCache.maximumSizeBytes = 128 << 20;
+  PaintingBinding.instance.imageCache.maximumSize = 1000;
+
   // Say so once, loudly, rather than letting the catalog screens fail with a
   // generic network error that looks like the backend is down.
   if (Env.missing.isNotEmpty) {

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -77,8 +77,7 @@ GoRouter buildRouter() {
             routes: [
               GoRoute(
                 path: '/home',
-                pageBuilder: (c, s) =>
-                    _fade(const _RootScroll(HomeScreen()), s),
+                pageBuilder: (c, s) => _fade(const HomeScreen(), s),
                 routes: _detailRoutes(),
               ),
             ],
@@ -340,6 +339,11 @@ List<RouteBase> _detailRoutes() => [
 ];
 
 /// Scroll + safe-area padding for the non-scrolling tab screens (Column roots).
+///
+/// Home is deliberately not one of them: it owns a CustomScrollView so its
+/// feed can be lazy. A SingleChildScrollView builds every child it is given,
+/// which for a twenty-section feed meant rebuilding all of it on any theme
+/// change.
 class _RootScroll extends StatelessWidget {
   const _RootScroll(this.child);
   final Widget child;

--- a/lib/screens/detail_screens.dart
+++ b/lib/screens/detail_screens.dart
@@ -26,6 +26,7 @@ import '../router/router.dart';
 import '../share/share_link.dart';
 import '../theme/tokens.dart';
 import '../widgets/album_art.dart';
+import '../widgets/download_glyph.dart';
 import '../widgets/playing_bars.dart';
 import '../widgets/ui.dart';
 
@@ -515,7 +516,7 @@ class _ApiTrackRow extends ConsumerWidget {
                 // download entry by song id; renders nothing for songs
                 // without a download (the common case), so empty rows
                 // stay clean.
-                _RowDownloadGlyph(songId: song.id, colors: c),
+                DownloadGlyph(songId: song.id, colors: c),
                 if (durationLabel != null) ...[
                   const SizedBox(width: 8),
                   Text(
@@ -600,49 +601,6 @@ String _stripHtml(String raw) {
 /// otherwise. Watches [downloadEntriesProvider] via the helper so it
 /// rebuilds on state transitions without bothering with per-chunk
 /// progress.
-class _RowDownloadGlyph extends ConsumerWidget {
-  const _RowDownloadGlyph({required this.songId, required this.colors});
-  final String songId;
-  final SunohColors colors;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final entry = watchDownloadEntry(ref, songId);
-    final state = entry?.state;
-    if (state == null) return const SizedBox.shrink();
-    return Padding(
-      padding: const EdgeInsets.only(left: 6),
-      child: switch (state) {
-        DownloadState.done => Icon(
-          SolarIconsBold.checkCircle,
-          size: 13,
-          color: colors.accent,
-        ),
-        DownloadState.downloading => Icon(
-          SolarIconsOutline.downloadMinimalistic,
-          size: 13,
-          color: colors.fgMute,
-        ),
-        DownloadState.queued => Icon(
-          SolarIconsOutline.clockCircle,
-          size: 13,
-          color: colors.fgMute,
-        ),
-        DownloadState.paused => Icon(
-          SolarIconsOutline.pauseCircle,
-          size: 13,
-          color: colors.fgMute,
-        ),
-        DownloadState.failed => Icon(
-          SolarIconsOutline.dangerCircle,
-          size: 13,
-          color: colors.fgMute,
-        ),
-      },
-    );
-  }
-}
-
 /// track row, tracking `position / duration`. Direct port of the RN
 /// `ActiveSongProgress` (album/ActiveSongProgress.tsx) — same six-stop
 /// low-alpha gradient. Listens to AppState's 1 Hz `positionTick` so only
@@ -840,7 +798,7 @@ class AlbumScreen extends ConsumerWidget {
       // Keep the loader up until the palette has resolved too — otherwise
       // the hero would briefly render with the deterministic accent and then
       // snap to the extracted tint, which reads as a half-loaded page.
-      if (!_paletteSettled(ref, pl.artwork)) {
+      if (!paletteSettled(ref, pl.artwork)) {
         return DetailLoading(colors: c);
       }
       return AlbumLikeBody(
@@ -870,7 +828,7 @@ class AlbumScreen extends ConsumerWidget {
       );
     }
     final al = async.requireValue;
-    if (!_paletteSettled(ref, al.artwork)) {
+    if (!paletteSettled(ref, al.artwork)) {
       return DetailLoading(colors: c);
     }
     return AlbumLikeBody(
@@ -896,7 +854,15 @@ class AlbumScreen extends ConsumerWidget {
 /// returned a palette, returned null, errored out, or there's no URL to
 /// extract from in the first place). Used by detail screens to delay reveal
 /// until the immersive hero can render in its final tinted state.
-bool _paletteSettled(WidgetRef ref, String? url) {
+/// Whether the artwork's palette has been extracted yet.
+///
+/// Detail screens hold their loader until this is true. Rendering the hero
+/// before it resolves means painting with the deterministic accent and then
+/// snapping to the extracted tint, which reads as a half-loaded page.
+///
+/// Public because the YouTube screens reuse [AlbumLikeBody] and therefore need
+/// to wait on exactly the same thing.
+bool paletteSettled(WidgetRef ref, String? url) {
   if (url == null || url.isEmpty) return true;
   return !ref.watch(artPaletteProvider(url)).isLoading;
 }
@@ -1479,7 +1445,7 @@ class ArtistScreen extends ConsumerWidget {
       );
     }
     final artist = async.requireValue;
-    if (!_paletteSettled(ref, artist.artwork)) {
+    if (!paletteSettled(ref, artist.artwork)) {
       return DetailLoading(colors: c, round: true);
     }
     return _ArtistBody(colors: c, artist: artist);

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -41,6 +41,25 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   // next launch).
   String? _promptedVersion;
 
+  /// Drives the tab-change fade. The body used to be wrapped in a
+  /// TweenAnimationBuilder, which only worked because it was a box; the feed
+  /// is slivers now, so the fade moves to SliverAnimatedOpacity and this is
+  /// the value it animates towards.
+  double _tabFade = 1;
+  String? _shownTab;
+
+  /// Restart the fade when the tab actually changes. Called from build, so it
+  /// mutates directly and schedules the settle for the next frame rather than
+  /// calling setState mid-build.
+  void _noteTab(String tab) {
+    if (_shownTab == tab) return;
+    _shownTab = tab;
+    _tabFade = 0;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) setState(() => _tabFade = 1);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final s = ref.watch(appStateProvider);
@@ -59,58 +78,68 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       });
     }
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Padding(
-          padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                'sunoh.',
-                style: SunohType.heading(
-                  fontSize: 22,
-                  color: c.fg,
-                  letterSpacing: -0.5,
+    _noteTab(s.topTab);
+
+    // Home owns its scrolling rather than sitting inside the shared
+    // _RootScroll, because that is a SingleChildScrollView and a
+    // SingleChildScrollView builds every one of its children. The music feed
+    // is over twenty sections, each with its own strip of artwork, so a single
+    // appStateProvider notification — the tint shifting back as you return
+    // from an album, say — rebuilt all of them at once. As slivers only the
+    // sections actually on screen get built.
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(
+          child: SizedBox(height: MediaQuery.of(context).padding.top),
+        ),
+        SliverToBoxAdapter(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 12, 20, 0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'sunoh.',
+                  style: SunohType.heading(
+                    fontSize: 22,
+                    color: c.fg,
+                    letterSpacing: -0.5,
+                  ),
                 ),
-              ),
-              IconBtn(
-                icon: SolarIconsOutline.settings,
-                color: c.fgDim,
-                size: 18,
-                width: 32,
-                height: 32,
-                onTap: () => context.openSettings(),
-              ),
-            ],
-          ),
-        ),
-        SunohTabs(
-          tabs: const ['Music', 'Podcasts', 'Audiobooks'],
-          active: s.topTab,
-          onChange: s.setTopTab,
-          colors: c,
-        ),
-        const SizedBox(height: 22),
-        TweenAnimationBuilder<double>(
-          key: ValueKey('tab-${s.topTab}'),
-          tween: Tween(begin: 0, end: 1),
-          duration: const Duration(milliseconds: 260),
-          curve: Curves.easeOut,
-          builder: (_, v, child) => Opacity(
-            opacity: v,
-            child: Transform.translate(
-              offset: Offset(0, (1 - v) * 6),
-              child: child,
+                IconBtn(
+                  icon: SolarIconsOutline.settings,
+                  color: c.fgDim,
+                  size: 18,
+                  width: 32,
+                  height: 32,
+                  onTap: () => context.openSettings(),
+                ),
+              ],
             ),
           ),
-          child: switch (s.topTab) {
-            'Podcasts' => PodcastsTab(colors: c),
-            'Audiobooks' => AudiobooksTab(colors: c),
+        ),
+        SliverToBoxAdapter(
+          child: SunohTabs(
+            tabs: const ['Music', 'Podcasts', 'Audiobooks'],
+            active: s.topTab,
+            onChange: s.setTopTab,
+            colors: c,
+          ),
+        ),
+        const SliverToBoxAdapter(child: SizedBox(height: 22)),
+        SliverAnimatedOpacity(
+          opacity: _tabFade,
+          duration: const Duration(milliseconds: 260),
+          curve: Curves.easeOut,
+          sliver: switch (s.topTab) {
+            'Podcasts' => SliverToBoxAdapter(child: PodcastsTab(colors: c)),
+            'Audiobooks' => SliverToBoxAdapter(child: AudiobooksTab(colors: c)),
             _ => MusicTab(colors: c),
           },
         ),
+        // Clears the mini player and nav bar, which the shell paints over the
+        // last 140 logical pixels of every screen.
+        const SliverToBoxAdapter(child: SizedBox(height: 140)),
       ],
     );
   }
@@ -433,21 +462,26 @@ class MusicTab extends ConsumerWidget {
     final gap = 40 * s.density.scale;
 
     return feedAsync.when(
-      loading: () => const _LoadingFeed(),
-      error: (e, _) => _ErrorFeed(
-        message: 'Couldn’t load the home feed.',
-        detail: '$e',
-        onRetry: () => ref.invalidate(homeFeedProvider(s.selectedLanguagesCsv)),
-        colors: c,
+      loading: () => const SliverToBoxAdapter(child: _LoadingFeed()),
+      error: (e, _) => SliverToBoxAdapter(
+        child: _ErrorFeed(
+          message: 'Couldn’t load the home feed.',
+          detail: '$e',
+          onRetry: () =>
+              ref.invalidate(homeFeedProvider(s.selectedLanguagesCsv)),
+          colors: c,
+        ),
       ),
       data: (sections) {
         final nonEmpty = sections.where((s) => s.items.isNotEmpty).toList();
         if (nonEmpty.isEmpty) {
-          return _ErrorFeed(
-            message: 'Nothing in the feed right now.',
-            colors: c,
-            onRetry: () =>
-                ref.invalidate(homeFeedProvider(s.selectedLanguagesCsv)),
+          return SliverToBoxAdapter(
+            child: _ErrorFeed(
+              message: 'Nothing in the feed right now.',
+              colors: c,
+              onRetry: () =>
+                  ref.invalidate(homeFeedProvider(s.selectedLanguagesCsv)),
+            ),
           );
         }
         // YouTube Music rows. Watched separately (not awaited alongside the
@@ -467,20 +501,39 @@ class MusicTab extends ConsumerWidget {
           everyN: _kYtInterleaveEvery,
         );
 
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            for (var i = 0; i < merged.length; i++) ...[
-              if (i > 0) SizedBox(height: gap),
+        // Widget instances, not built widgets. Constructing twenty-odd of
+        // these is nothing; it is their build methods — each resolving a
+        // strip of artwork — that cost, and the delegate below only calls
+        // those for rows actually on screen.
+        final rows = <Widget>[];
+        for (var i = 0; i < merged.length; i++) {
+          rows.add(
+            Padding(
+              padding: EdgeInsets.only(top: i == 0 ? 0 : gap),
               // First section gets the big feature-tile treatment (matches the
               // prototype's "Editorial picks" hierarchy).
-              _ApiSection(section: merged[i], colors: c, featured: i == 0),
-              // Moods & genres sits after the first couple of rows — high
-              // enough to be discoverable, not so high it displaces the feed.
-              if (i == 1) ...[SizedBox(height: gap), _MoodsRow(colors: c)],
-            ],
-            const SizedBox(height: 20),
-          ],
+              child: _ApiSection(
+                section: merged[i],
+                colors: c,
+                featured: i == 0,
+              ),
+            ),
+          );
+          // Moods & genres sits after the first couple of rows — high enough
+          // to be discoverable, not so high it displaces the feed.
+          if (i == 1) {
+            rows.add(
+              Padding(
+                padding: EdgeInsets.only(top: gap),
+                child: _MoodsRow(colors: c),
+              ),
+            );
+          }
+        }
+
+        return SliverList.builder(
+          itemCount: rows.length,
+          itemBuilder: (_, i) => rows[i],
         );
       },
     );

--- a/lib/screens/liked_songs_screen.dart
+++ b/lib/screens/liked_songs_screen.dart
@@ -14,6 +14,7 @@ import '../api/dto.dart';
 import '../overlays/track_menu_sheet.dart';
 import '../providers/app_state_provider.dart';
 import '../theme/tokens.dart';
+import '../widgets/download_glyph.dart';
 import '../widgets/ui.dart';
 
 class LikedSongsScreen extends ConsumerStatefulWidget {
@@ -376,6 +377,7 @@ class _LikedTrackRow extends ConsumerWidget {
                 ],
               ),
             ),
+            DownloadGlyph(songId: song.id, colors: c),
             IconBtn(
               icon: SolarIconsBold.heart,
               color: accent,

--- a/lib/screens/user_playlist_screen.dart
+++ b/lib/screens/user_playlist_screen.dart
@@ -20,6 +20,7 @@ import '../data/user_playlist.dart';
 import '../overlays/track_menu_sheet.dart';
 import '../providers/app_state_provider.dart';
 import '../theme/tokens.dart';
+import '../widgets/download_glyph.dart';
 import '../widgets/ui.dart';
 
 class UserPlaylistScreen extends ConsumerStatefulWidget {
@@ -652,6 +653,7 @@ class _PlaylistTrackRow extends ConsumerWidget {
                 ],
               ),
             ),
+            DownloadGlyph(songId: song.id, colors: c),
             IconBtn(
               icon: SolarIconsBold.menuDots,
               color: colors.fgMute,

--- a/lib/screens/ytmusic_screens.dart
+++ b/lib/screens/ytmusic_screens.dart
@@ -18,7 +18,7 @@ import '../router/router.dart';
 import '../theme/tokens.dart';
 import '../widgets/album_art.dart';
 import '../widgets/ui.dart';
-import 'detail_screens.dart' show AlbumLikeBody;
+import 'detail_screens.dart' show AlbumLikeBody, DetailLoading, paletteSettled;
 
 /// Shared chrome: back chip + big title, matching SectionScreen.
 class _YtScaffold extends StatelessWidget {
@@ -103,11 +103,12 @@ class YtPlaylistScreen extends ConsumerWidget {
     final async = ref.watch(ytMusicPlaylistProvider(browseId));
 
     return async.when(
-      loading: () => _YtScaffold(
-        title: name ?? 'Playlist',
-        colors: c,
-        children: [_loading(c)],
-      ),
+      // DetailLoading, not the title-only scaffold this used to show. The
+      // data state below is AlbumLikeBody — a scroll-shrink hero — so a
+      // heading-and-spinner loader meant the screen visibly changed shape
+      // once the response landed. saavn and gaana never did that because
+      // they use this skeleton, which is the shape of what is coming.
+      loading: () => DetailLoading(colors: c),
       error: (e, _) => _YtScaffold(
         title: name ?? 'Playlist',
         colors: c,
@@ -120,6 +121,10 @@ class YtPlaylistScreen extends ConsumerWidget {
             colors: c,
             children: [_error(c, 'This playlist isn\u2019t available.')],
           );
+        }
+        // Same wait the saavn/gaana screens do — see paletteSettled.
+        if (!paletteSettled(ref, detail.artwork)) {
+          return DetailLoading(colors: c);
         }
         // Reuse the album/playlist body the rest of the app uses, rather
         // than a bespoke layout — that's what gives YouTube playlists the

--- a/lib/widgets/album_art.dart
+++ b/lib/widgets/album_art.dart
@@ -157,12 +157,23 @@ class SunohArt extends StatelessWidget {
     // (~1008px of actual surface) and looking soft no matter how large the
     // source was. 1200 matches the largest art the CDN serves.
     //
-    // Only the hero reaches the top tier — home tiles stay at 192/384, so
-    // this doesn't undo the scroll work.
+    // The 512 rung exists because the ladder used to jump 384 -> 720, and the
+    // comment here used to claim home tiles stayed at 192/384. That was only
+    // true at 2x. A ~148pt card on a 1080-wide phone needs ~390-444px, which
+    // cleared 384 and landed on 720 — a 2.07 MB bitmap for a tile that wants
+    // 0.79 MB. Measured on a device: 390 images holding 318 MiB, which is why
+    // the feed's art was being evicted and re-decoded on every trip into a
+    // detail screen. Rounding those to 512 is ~1.05 MB instead.
+    //
+    // The rungs stay coarse on purpose: their job is to make several display
+    // sizes of one URL share a single decoded bitmap, and every extra rung is
+    // one more way for two cards to miss each other.
     final cacheTier = largest <= 192
         ? 192
         : largest <= 384
         ? 384
+        : largest <= 512
+        ? 512
         : largest <= 720
         ? 720
         : 1200;

--- a/lib/widgets/download_glyph.dart
+++ b/lib/widgets/download_glyph.dart
@@ -1,0 +1,110 @@
+// A song's download state, small enough to live in a track row.
+//
+// The percentage used to exist only inside the track menu sheet, which meant
+// starting a download and then wanting to know how it was going cost two taps
+// and covered the list you were looking at. A row can say it itself.
+//
+// The ring is the reason this is split into two widgets. Per-byte progress
+// arrives on a stream per chunk, and a row that watched it would rebuild
+// constantly for every song in the list — including the overwhelming majority
+// that are not downloading. Only [_ProgressRing] subscribes, and it only
+// exists while a download is actually running, so an idle list holds no
+// subscriptions at all.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:solar_icons/solar_icons.dart';
+
+import '../audio/download_store.dart';
+import '../providers/downloads_provider.dart';
+import '../theme/tokens.dart';
+
+class DownloadGlyph extends ConsumerWidget {
+  const DownloadGlyph({
+    super.key,
+    required this.songId,
+    required this.colors,
+    this.size = 13,
+  });
+
+  final String songId;
+  final SunohColors colors;
+  final double size;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = watchDownloadEntry(ref, songId)?.state;
+    // The common case by a wide margin: nothing to say, so nothing rendered.
+    if (state == null) return const SizedBox.shrink();
+
+    return Padding(
+      padding: const EdgeInsets.only(left: 6),
+      child: switch (state) {
+        DownloadState.downloading => _ProgressRing(
+          songId: songId,
+          colors: colors,
+          size: size,
+        ),
+        DownloadState.done => Icon(
+          SolarIconsBold.checkCircle,
+          size: size,
+          color: colors.accent,
+        ),
+        DownloadState.queued => Icon(
+          SolarIconsOutline.clockCircle,
+          size: size,
+          color: colors.fgMute,
+        ),
+        DownloadState.paused => Icon(
+          SolarIconsOutline.pauseCircle,
+          size: size,
+          color: colors.fgMute,
+        ),
+        DownloadState.failed => Icon(
+          SolarIconsOutline.dangerCircle,
+          size: size,
+          color: colors.fgMute,
+        ),
+      },
+    );
+  }
+}
+
+/// The live ring. Mounted only while a song is downloading — see the file
+/// header for why that matters.
+class _ProgressRing extends ConsumerWidget {
+  const _ProgressRing({
+    required this.songId,
+    required this.colors,
+    required this.size,
+  });
+
+  final String songId;
+  final SunohColors colors;
+  final double size;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final progress = ref.watch(downloadProgressProvider(songId)).asData?.value;
+    // Null until the first chunk lands, and null when the server sends no
+    // content-length. CircularProgressIndicator spins on a null value, which
+    // is the honest thing to show for "started, size unknown" rather than a
+    // ring frozen at zero that looks stuck.
+    final value = progress == null || progress.total <= 0
+        ? null
+        : progress.fraction;
+
+    return RepaintBoundary(
+      child: SizedBox(
+        width: size + 3,
+        height: size + 3,
+        child: CircularProgressIndicator(
+          value: value,
+          strokeWidth: 2,
+          color: colors.accent,
+          backgroundColor: colors.line,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Two bugs reported together, plus the feed paging that made one of them visible.

## The home feed was showing a fifth of what it has

The personalized feed returned three rows where music.youtube.com shows about fifteen. Not a parsing failure: YouTube Music serves the home feed a few shelves at a time and the web client fetches the rest as you scroll. We only ever read the first response.

`_browseSections` now follows the continuation token. Measured on a signed-in device: **3 sections → 15**.

Capped at five pages rather than exhaustive — the feed is effectively endless, every page is a round trip, and rows nobody scrolls to cost the same as rows they do. A failed page ends the walk and keeps what came before it. Only the personalized page is paged; explore/charts/new-releases are fixed shelves that do not grow.

The token is read in two shapes and the responses in three, because InnerTube is mid-migration. An unrecognised shape ends the walk instead of throwing.

## The YouTube playlist screen changed shape as it loaded

It showed a title-only scaffold while loading and then swapped to `AlbumLikeBody`, a scroll-shrink hero — two different layouts, so the screen visibly rearranged when the response landed. saavn and gaana never did this because they use `DetailLoading`, a skeleton shaped like what is coming. YouTube uses it now, and also waits for the artwork palette before painting the hero, removing a second smaller jump where the accent snapped to the extracted tint.

## Every image re-rendered on the way back from a detail screen

`_RootScroll` is a `SingleChildScrollView`, which builds every child it is given — laziness is not optional there, it does not exist. `MusicTab` handed it a `Column` of every section, so all of them and their artwork strips rebuilt on any `appStateProvider` notification. Returning from an album is one of those when tint-from-artwork is on.

Home owns a `CustomScrollView` now and the feed is a `SliverList.builder`, so only sections actually on screen are built. Search and Library keep `_RootScroll`; their content is small enough not to care.

**This was made bad enough to notice by the continuation paging above**, which took the feed from ~10 sections to 23. The eager build was already against this repo's own lazy-list rule before that.

### Two things found while chasing it

- **The decode tier ladder was wrong at 3x.** A ~148pt card needs ~444px, which cleared the 384 rung and landed on 720 — a 2.07 MB bitmap for a tile that wants 0.79 MB. The comment above it claimed home tiles stayed at 192/384, which was only ever true at 2x. Added a 512 rung.
- **Flutter's default 100 MiB image cache therefore held only ~48 images**, fewer than one screen plus a detail page. Raised to 128 MiB, which now holds ~190.

The cache was my first suspect and it was the wrong one. Measured on a device it sits pinned at whatever ceiling it is given, evicting constantly, with no flicker either way. It was briefly 320 MiB while I chased that, which fixed nothing and is far too much native bitmap for a phone this app is meant to behave on.

## Download progress on the track row

The percentage existed only inside the track menu sheet, so checking on a download cost two taps and covered the list you were looking at. The row shows a real ring now instead of a static icon.

Per-byte progress arrives on a stream per chunk, so the subscription is deliberately not in the row: it lives in an inner widget that exists only while a download is running. An idle list holds no progress subscriptions, and rows that are not downloading never rebuild for a chunk that is not theirs.

The glyph only existed on detail-screen track rows, so a download started from Liked Songs or a user playlist was invisible there. It is a shared widget now and both use it. Local tracks are excluded — files on the phone, not downloads.

## Note

The tab-change fade moved from `TweenAnimationBuilder` to `SliverAnimatedOpacity`, since the old one only worked while the body was a box. The 6px slide that went with it is gone; it does not translate to slivers without contorting the structure.

## Testing

173 tests pass, analyzer reports nothing new (8 pre-existing warnings).

Verified on device: feed paging 3 → 15 sections, the loading jump gone, and the image re-render gone. The image-cache number was confirmed by instrumenting `imageCache` live on the device and reading it back — that instrumentation is removed in the final commit.
