### PR TITLE
Gaana downloads, on-device library browsing, and three startup bugs

### DIFF
--- a/android/app/src/main/kotlin/codes/afk/sunoh/MainActivity.kt
+++ b/android/app/src/main/kotlin/codes/afk/sunoh/MainActivity.kt
@@ -113,8 +113,15 @@ class MainActivity : AudioServiceActivity() {
         // The device's own music library. Off the main thread: a MediaStore
         // query over a few thousand tracks, resolving album art per album,
         // takes long enough to drop frames if run inline.
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, LOCAL_CHANNEL)
-            .setMethodCallHandler { call, result ->
+        val localChannel =
+            MethodChannel(flutterEngine.dartExecutor.binaryMessenger, LOCAL_CHANNEL)
+        // Music copied onto the phone should appear on its own. The bridge
+        // debounces the burst of per-row notifications a file copy produces
+        // and calls back once; Dart decides whether a rescan is worth it.
+        LocalMediaBridge.observeChanges(applicationContext) {
+            localChannel.invokeMethod("libraryChanged", null)
+        }
+        localChannel.setMethodCallHandler { call, result ->
                 when (call.method) {
                     "scan" -> {
                         localScope.launch {

--- a/android/app/src/main/kotlin/codes/afk/sunoh/localmedia/LocalMediaBridge.kt
+++ b/android/app/src/main/kotlin/codes/afk/sunoh/localmedia/LocalMediaBridge.kt
@@ -2,8 +2,12 @@ package codes.afk.sunoh.localmedia
 
 import android.content.ContentUris
 import android.content.Context
+import android.database.ContentObserver
 import android.database.Cursor
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.media.MediaMetadataRetriever
 import android.os.Build
 import android.provider.MediaStore
 import android.util.Log
@@ -42,6 +46,44 @@ object LocalMediaBridge {
     private const val ART_DIR = "local_album_art"
     private const val ART_SIZE = 512
 
+    /** See [observeChanges] for why a copy needs settling time. */
+    private const val CHANGE_DEBOUNCE_MS = 1_000L
+
+    /**
+     * Fires when the device's audio collection changes, so music copied onto
+     * the phone shows up without a pull-to-refresh.
+     *
+     * Debounced, because a file copy is not one notification: MediaStore emits
+     * per row, and a folder of forty tracks would otherwise queue forty scans
+     * of the entire library. One rescan a second after things go quiet is what
+     * the user actually wants.
+     */
+    private var observer: ContentObserver? = null
+
+    fun observeChanges(context: Context, onChanged: () -> Unit) {
+        if (observer != null) return
+        val handler = Handler(Looper.getMainLooper())
+        val debounce = Runnable { onChanged() }
+        val obs = object : ContentObserver(handler) {
+            override fun onChange(selfChange: Boolean, uri: Uri?) {
+                handler.removeCallbacks(debounce)
+                handler.postDelayed(debounce, CHANGE_DEBOUNCE_MS)
+            }
+        }
+        context.contentResolver.registerContentObserver(
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            true,
+            obs,
+        )
+        observer = obs
+        Log.i(TAG, "watching MediaStore for changes")
+    }
+
+    fun stopObserving(context: Context) {
+        observer?.let { context.contentResolver.unregisterContentObserver(it) }
+        observer = null
+    }
+
     /**
      * Every audio file MediaStore considers music, newest first.
      *
@@ -61,6 +103,16 @@ object LocalMediaBridge {
             MediaStore.Audio.Media.TRACK,
             MediaStore.Audio.Media.YEAR,
             MediaStore.Audio.Media.DATE_ADDED,
+            // GENRE arrived in API 30 and minSdk is 24, so it is asked for
+            // only where it exists. Querying a column the platform does not
+            // have throws rather than returning null.
+            *(
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    arrayOf(MediaStore.Audio.Media.GENRE)
+                } else {
+                    emptyArray()
+                }
+            ),
         )
 
         // IS_MUSIC excludes ringtones, alarms and notifications, which
@@ -101,6 +153,8 @@ object LocalMediaBridge {
             val trackCol = c.getColumnIndexOrThrow(MediaStore.Audio.Media.TRACK)
             val yearCol = c.getColumnIndexOrThrow(MediaStore.Audio.Media.YEAR)
             val addedCol = c.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_ADDED)
+            // getColumnIndex, not OrThrow: absent below API 30 by design.
+            val genreCol = c.getColumnIndex(MediaStore.Audio.Media.GENRE)
 
             while (c.moveToNext()) {
                 val id = c.getLong(idCol)
@@ -111,7 +165,13 @@ object LocalMediaBridge {
                 if (path.isNullOrEmpty() || !File(path).exists()) continue
 
                 val albumId = c.getLong(albumIdCol)
-                val art = artByAlbum.getOrPut(albumId) { albumArtPath(context, albumId) }
+                // Album art first, then the file's own embedded picture. A
+                // track MediaStore never indexed art for is common with loose
+                // files, and falling back means they show a cover instead of
+                // the painted placeholder.
+                val art = artByAlbum.getOrPut(albumId) {
+                    albumArtPath(context, albumId) ?: embeddedArtPath(context, albumId, path)
+                }
 
                 out.add(
                     mapOf(
@@ -127,6 +187,9 @@ object LocalMediaBridge {
                         "track" to c.getInt(trackCol),
                         "year" to c.getInt(yearCol),
                         "dateAdded" to c.getLong(addedCol),
+                        "genre" to (
+                            if (genreCol >= 0) c.getString(genreCol) else null
+                        ),
                         "artPath" to art,
                     )
                 )
@@ -180,6 +243,37 @@ object LocalMediaBridge {
             // Write a zero-byte marker so the next scan skips the attempt
             // instead of paying for the same exception again.
             markMissing(file)
+        }
+    }
+
+    /**
+     * The picture embedded in the file itself, cached like album art.
+     *
+     * MediaStore only indexes album art it has decided an album has, which
+     * leaves loose files — a single dropped in Download, anything with tags
+     * MediaStore did not group — showing the painted placeholder despite
+     * carrying a perfectly good cover.
+     *
+     * Cached under the same album id and marked missing the same way, so a
+     * file with no embedded picture costs one retriever open, once, ever.
+     * MediaMetadataRetriever is expensive enough that paying it per scan would
+     * be felt on a large library.
+     */
+    private fun embeddedArtPath(context: Context, albumId: Long, path: String): String? {
+        val dir = File(context.cacheDir, ART_DIR).apply { mkdirs() }
+        val file = File(dir, "embedded-$albumId.jpg")
+        if (file.exists()) return if (file.length() > 0) file.absolutePath else null
+
+        val retriever = MediaMetadataRetriever()
+        return try {
+            retriever.setDataSource(path)
+            val bytes = retriever.embeddedPicture ?: return markMissing(file)
+            FileOutputStream(file).use { out -> out.write(bytes) }
+            file.absolutePath
+        } catch (e: Exception) {
+            markMissing(file)
+        } finally {
+            runCatching { retriever.release() }
         }
     }
 

--- a/lib/api/local_media_channel.dart
+++ b/lib/api/local_media_channel.dart
@@ -12,6 +12,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'dto.dart';
+import 'local_sort.dart';
 
 /// A group of on-device tracks sharing an album or an artist.
 ///
@@ -71,16 +72,21 @@ class LocalScan {
     required this.albums,
     required this.artists,
     this.folders = const [],
+    this.meta = const {},
   });
   const LocalScan.empty()
     : songs = const [],
       albums = const [],
       artists = const [],
-      folders = const [];
+      folders = const [],
+      meta = const {};
 
   final List<FeedItem> songs;
   final List<LocalCollection> albums;
   final List<LocalCollection> artists;
+
+  /// Sortable per-track fields, keyed by song id. See [LocalTrackMeta].
+  final Map<String, LocalTrackMeta> meta;
 
   /// Every folder the scan saw, **including ones left out**, largest first.
   ///
@@ -114,6 +120,48 @@ String folderLocation(String path) {
   final i = p.lastIndexOf('/');
   final parent = i <= 0 ? '' : p.substring(1, i);
   return parent.isEmpty ? 'Internal storage' : parent;
+}
+
+/// Sortable fields MediaStore gives us that [FeedItem] has no room for.
+///
+/// Kept beside the songs rather than added to FeedItem: that DTO is shared by
+/// every source, and a track number means nothing to a YouTube result. Keyed
+/// by song id in [LocalScan.meta].
+class LocalTrackMeta {
+  const LocalTrackMeta({
+    required this.disc,
+    required this.track,
+    required this.dateAdded,
+    this.genre,
+  });
+
+  /// Disc number, 1 when the file does not say.
+  final int disc;
+
+  /// Track number within the disc, 0 when the file does not say.
+  final int track;
+
+  /// Epoch seconds, as MediaStore reports it.
+  final int dateAdded;
+
+  final String? genre;
+
+  /// MediaStore packs multi-disc albums into one integer as
+  /// `disc * 1000 + track`, so track 1 of disc 2 arrives as 2001. Anything
+  /// below 1000 is a plain track number on a single-disc release.
+  factory LocalTrackMeta.fromRow(Map<Object?, Object?> row) {
+    final raw = _intOf(row['track']);
+    final genre = (row['genre'] ?? '').toString().trim();
+    return LocalTrackMeta(
+      disc: raw >= 1000 ? raw ~/ 1000 : 1,
+      track: raw >= 1000 ? raw % 1000 : raw,
+      dateAdded: _intOf(row['dateAdded']),
+      genre: genre.isEmpty ? null : genre,
+    );
+  }
+
+  static int _intOf(Object? v) =>
+      v is int ? v : int.tryParse((v ?? '').toString()) ?? 0;
 }
 
 /// Which folders the on-device library takes music from.
@@ -239,6 +287,12 @@ class FolderRules {
   }
 }
 
+/// The last segment of a folder path — what a person calls the folder.
+String folderNameOf(String path) {
+  final i = path.lastIndexOf('/');
+  return i < 0 ? path : path.substring(i + 1);
+}
+
 /// The directory part of a file path, or empty when there isn't one.
 String folderOf(String path) {
   final i = path.lastIndexOf('/');
@@ -254,6 +308,16 @@ const String kLocalSource = 'local';
 class LocalMediaChannel {
   LocalMediaChannel._();
   static final LocalMediaChannel instance = LocalMediaChannel._();
+
+  /// Called when the device's audio collection changes. The native side
+  /// debounces the burst a file copy produces, so this fires once per settled
+  /// change rather than once per file.
+  void onLibraryChanged(void Function() handler) {
+    if (!_supported) return;
+    _channel.setMethodCallHandler((call) async {
+      if (call.method == 'libraryChanged') handler();
+    });
+  }
 
   static const MethodChannel _channel = MethodChannel(
     'codes.afk.sunoh/localmedia',
@@ -303,6 +367,7 @@ class LocalMediaChannel {
     final artistNames = <String, String>{};
     // Counted over every row, included or not — see LocalScan.folders.
     final folderCounts = <String, int>{};
+    final meta = <String, LocalTrackMeta>{};
 
     for (final row in rows) {
       if (row is! Map) continue;
@@ -319,6 +384,7 @@ class LocalMediaChannel {
       if (!rules.allows(folder)) continue;
 
       songs.add(song);
+      meta[song.id] = LocalTrackMeta.fromRow(r);
 
       final artist = _clean((r['artist'] ?? '').toString());
       final album = _clean((r['album'] ?? '').toString());
@@ -366,6 +432,7 @@ class LocalMediaChannel {
                 'default ${rules.defaultIncluded ? 'in' : 'out'}'})',
     );
     return LocalScan(
+      meta: meta,
       songs: songs,
       albums: [
         for (final e in albums.entries)
@@ -373,7 +440,12 @@ class LocalMediaChannel {
             id: e.key,
             name: albumNames[e.key] ?? '',
             subtitle: _albumArtist(albumArtistSets[e.key]),
-            songs: e.value,
+            // Track order is not a preference inside an album: the scan
+            // returns rows newest-file-first, so an album opened from the
+            // device library was listing its songs in the order they were
+            // copied onto the phone. Applied here so every consumer gets it —
+            // the detail screen, Android Auto, "play album".
+            songs: sortAlbumTracks(e.value, meta),
           ),
       ],
       artists: [

--- a/lib/api/local_sort.dart
+++ b/lib/api/local_sort.dart
@@ -1,0 +1,145 @@
+// How the on-device library is ordered.
+//
+// The scan returns MediaStore's own order, newest file first, and that used to
+// be the only order there was. It is a reasonable default and a poor only
+// option: a library you have had for years is mostly not sorted by when the
+// files happened to land on the phone.
+//
+// Lives in api/ rather than audio/ because it is pure ordering over the DTOs
+// defined here, and api/ must not depend upward on audio/.
+//
+// Track number is deliberately not in this list. It is not a way to sort a
+// library — it is the correct order *within an album*, applied there
+// regardless of what the library is sorted by, because track 7 before track 2
+// is simply wrong.
+
+import 'dto.dart';
+import 'local_media_channel.dart';
+
+enum LocalSort { dateAdded, title, artist, album, duration, year }
+
+extension LocalSortLabel on LocalSort {
+  String get label => switch (this) {
+    LocalSort.dateAdded => 'Date added',
+    LocalSort.title => 'Title',
+    LocalSort.artist => 'Artist',
+    LocalSort.album => 'Album',
+    LocalSort.duration => 'Duration',
+    LocalSort.year => 'Year',
+  };
+
+  /// What ascending means for this field, in words. "A to Z" and "Oldest
+  /// first" are the same direction and reading either as "ascending" is a
+  /// small tax on everyone who uses the menu.
+  String get ascendingLabel => switch (this) {
+    LocalSort.dateAdded => 'Oldest first',
+    LocalSort.duration => 'Shortest first',
+    LocalSort.year => 'Oldest first',
+    _ => 'A to Z',
+  };
+
+  String get descendingLabel => switch (this) {
+    LocalSort.dateAdded => 'Newest first',
+    LocalSort.duration => 'Longest first',
+    LocalSort.year => 'Newest first',
+    _ => 'Z to A',
+  };
+
+  /// Stored in Hive, so the name rather than the index — reordering the enum
+  /// should not silently change someone's saved preference.
+  String get key => name;
+
+  static LocalSort fromKey(String? key) => LocalSort.values.firstWhere(
+    (s) => s.name == key,
+    orElse: () => LocalSort.dateAdded,
+  );
+}
+
+/// Sort [songs] in place-safe fashion, returning a new list.
+///
+/// Ties fall back to title so the order is stable: without it, two songs from
+/// the same album in an album sort swap places between rebuilds, which reads
+/// as the list flickering.
+List<FeedItem> sortLocalSongs(
+  List<FeedItem> songs,
+  Map<String, LocalTrackMeta> meta, {
+  required LocalSort by,
+  required bool ascending,
+}) {
+  int compare(FeedItem a, FeedItem b) {
+    final result = switch (by) {
+      LocalSort.title => _text(a.title, b.title),
+      LocalSort.artist => _text(_artistOf(a), _artistOf(b)),
+      LocalSort.album => _text(_albumOf(a), _albumOf(b)),
+      LocalSort.duration => _int(a.duration, b.duration),
+      LocalSort.year => _int(a.releaseDate, b.releaseDate),
+      LocalSort.dateAdded => (meta[a.id]?.dateAdded ?? 0).compareTo(
+        meta[b.id]?.dateAdded ?? 0,
+      ),
+    };
+    if (result != 0) return result;
+    return _text(a.title, b.title);
+  }
+
+  final out = [...songs]..sort(compare);
+  return ascending ? out : out.reversed.toList();
+}
+
+/// Album order: disc, then track, then title for anything untagged.
+///
+/// Applied inside an album whatever the library sort is. MediaStore returns
+/// rows newest-file-first and that order was flowing straight through, so an
+/// album opened from the device library listed its songs in the order they
+/// were copied onto the phone.
+List<FeedItem> sortAlbumTracks(
+  List<FeedItem> songs,
+  Map<String, LocalTrackMeta> meta,
+) {
+  final out = [...songs];
+  out.sort((a, b) {
+    final ma = meta[a.id];
+    final mb = meta[b.id];
+    final disc = (ma?.disc ?? 1).compareTo(mb?.disc ?? 1);
+    if (disc != 0) return disc;
+    // Untagged tracks sort after numbered ones rather than jumping to the top
+    // as track zero.
+    final ta = (ma?.track ?? 0) == 0 ? 1 << 20 : ma!.track;
+    final tb = (mb?.track ?? 0) == 0 ? 1 << 20 : mb!.track;
+    if (ta != tb) return ta.compareTo(tb);
+    return _text(a.title, b.title);
+  });
+  return out;
+}
+
+/// Case- and accent-insensitive enough for a music library, without pulling in
+/// a collation package: lowercase, and leading articles ignored so "The Wall"
+/// files under W.
+int _text(String a, String b) => _sortKey(a).compareTo(_sortKey(b));
+
+String _sortKey(String raw) {
+  var s = raw.trim().toLowerCase();
+  for (final article in const ['the ', 'a ', 'an ']) {
+    if (s.startsWith(article)) {
+      s = s.substring(article.length);
+      break;
+    }
+  }
+  return s;
+}
+
+int _int(String? a, String? b) =>
+    (int.tryParse(a ?? '') ?? 0).compareTo(int.tryParse(b ?? '') ?? 0);
+
+String _artistOf(FeedItem s) {
+  final artists = s.artists;
+  if (artists != null && artists.isNotEmpty) return artists.first.name;
+  return s.subtitle ?? '';
+}
+
+String _albumOf(FeedItem s) {
+  // The local mapper packs "artist · album" into the subtitle, so the album is
+  // whatever follows the separator when there is one.
+  final sub = s.subtitle ?? '';
+  final i = sub.indexOf(' · ');
+  return i >= 0 ? sub.substring(i + 3) : sub;
+}

--- a/lib/audio/audio_handler.dart
+++ b/lib/audio/audio_handler.dart
@@ -523,6 +523,34 @@ class SunohAudioHandler {
   final Map<String, int> _loadFailRetries = {};
   static const _maxRetries = 2;
 
+  /// The song playback stopped on because it would not load, and the backoff
+  /// that keeps trying it.
+  ///
+  /// Without this, a track that cannot load lets mpv advance to the next one —
+  /// which, when the reason is "there is no network", cannot load either. The
+  /// result was the whole queue flicking past in a couple of seconds and
+  /// landing on silence at the end. Stopping on the track that failed is both
+  /// the honest thing to show and the only state you can resume from.
+  String? _stalledSongId;
+  Timer? _stallRetry;
+  int _stallAttempts = 0;
+
+  /// Backoff between retries, then every minute. Retrying is how the network
+  /// coming back is noticed: a resolve that succeeds is a connection, and no
+  /// connectivity plugin has to be added to learn it.
+  static const _stallBackoff = [
+    Duration(seconds: 5),
+    Duration(seconds: 10),
+    Duration(seconds: 20),
+    Duration(seconds: 30),
+    Duration(minutes: 1),
+  ];
+
+  /// After this many the timer stops and playback waits for a tap on play.
+  /// Roughly a quarter of an hour of trying, which is long enough to cover a
+  /// tunnel and short enough not to poll all night on a dead connection.
+  static const _maxStallRetries = 18;
+
   void _onError(MpvPlayerError err) {
     // ignore: avoid_print
     print('[mpv error] $err');
@@ -532,12 +560,8 @@ class SunohAudioHandler {
 
     final tries = _loadFailRetries[song.id] ?? 0;
     if (tries >= _maxRetries) {
-      // ignore: avoid_print
-      print(
-        '[audio] giving up on ${song.id} ("${song.title}") '
-        'after $tries retries — mpv will auto-advance to next',
-      );
       _loadFailRetries.remove(song.id);
+      _stallOn(song);
       return;
     }
     _loadFailRetries[song.id] = tries + 1;
@@ -547,6 +571,56 @@ class SunohAudioHandler {
       '(try ${tries + 1}/$_maxRetries) — force-refresh',
     );
     unawaited(_refreshCurrentTrack());
+  }
+
+  /// Stop on [song] rather than letting mpv walk the rest of the queue.
+  ///
+  /// Called once the per-song retries are spent. Pausing is what stops the
+  /// cascade: mpv advances on a load failure, and every following track fails
+  /// for the same reason.
+  void _stallOn(FeedItem song) {
+    if (_stalledSongId == song.id) {
+      _stallAttempts++;
+    } else {
+      _stalledSongId = song.id;
+      _stallAttempts = 0;
+    }
+    // ignore: avoid_print
+    print(
+      '[audio] cannot load ${song.id} ("${song.title}") — stopping here '
+      '(attempt $_stallAttempts), will retry',
+    );
+    unawaited(_player.pause());
+    _scheduleStallRetry();
+  }
+
+  void _scheduleStallRetry() {
+    _stallRetry?.cancel();
+    if (_stallAttempts >= _maxStallRetries) {
+      // ignore: avoid_print
+      print('[audio] giving up retrying — waiting for play');
+      return;
+    }
+    final delay =
+        _stallBackoff[_stallAttempts.clamp(0, _stallBackoff.length - 1)];
+    _stallRetry = Timer(delay, () {
+      final id = _stalledSongId;
+      if (id == null) return;
+      // Fresh per-song tries, so a retry that half-works still gets its own
+      // couple of goes before stalling again.
+      _loadFailRetries.remove(id);
+      unawaited(_refreshCurrentTrack());
+    });
+  }
+
+  /// Playback is healthy again — drop the stall so a later failure starts its
+  /// own backoff rather than inheriting this one's.
+  void _clearStall() {
+    if (_stalledSongId == null && _stallRetry == null) return;
+    _stalledSongId = null;
+    _stallAttempts = 0;
+    _stallRetry?.cancel();
+    _stallRetry = null;
   }
 
   // ── on_load hook (decomposed) ─────────────────────────────────────────
@@ -563,6 +637,8 @@ class SunohAudioHandler {
       if (resolved == null) return;
       await _applyResolvedHeaders(resolved.httpHeaders);
       await _applyResolvedUrl(resolved.url);
+      // Resolved and handed to mpv, so whatever was wrong is over.
+      _clearStall();
       _mergeEnrichmentIfAny(song.id, resolved.enriched);
       await _applyPendingStartPosition(song.id);
       _urlRefresh.schedule(songId: song.id, resolvedUrl: resolved.url);
@@ -710,6 +786,7 @@ class SunohAudioHandler {
       _byId[s.id] = s;
     }
     _loadFailRetries.clear();
+    _clearStall();
     _userPlaying = true;
     _pausedForInterruption = false;
     await _activateSession();
@@ -735,6 +812,7 @@ class SunohAudioHandler {
       _byId[s.id] = s;
     }
     _loadFailRetries.clear();
+    _clearStall();
     _userPlaying = false;
     _pendingStartPosition = seekTo;
     // Tag the target song so the load hook only consumes the pending
@@ -764,6 +842,7 @@ class SunohAudioHandler {
     // Manual play overrides any pending auto-resume from an interruption.
     _pausedForInterruption = false;
     _loadFailRetries.clear();
+    _clearStall();
     await _activateSession();
 
     // Resume safety net for long pauses. Background timers can be
@@ -779,6 +858,15 @@ class SunohAudioHandler {
       // ignore: avoid_print
       print('[audio] play() refreshing ${song.id} ("${song.title}")');
       await _refreshCurrentTrack();
+    }
+
+    // An explicit try-again: the backoff may have run out while the phone was
+    // somewhere with no signal, and a tap on play should not be ignored
+    // because of that.
+    if (_stalledSongId != null) {
+      _loadFailRetries.remove(_stalledSongId);
+      _stallAttempts = 0;
+      _scheduleStallRetry();
     }
 
     await _player.play();
@@ -884,6 +972,7 @@ class SunohAudioHandler {
 
   Future<void> clearQueue() async {
     _loadFailRetries.clear();
+    _clearStall();
     await _player.clearPlaylist();
     // Pre-clear our mirrors — the playlist stream will sync them too but
     // we want subsequent reads in the same microtask to see empty.
@@ -938,6 +1027,7 @@ class SunohAudioHandler {
   // ── Cleanup ────────────────────────────────────────────────────────────
   Future<void> dispose() async {
     _urlRefresh.dispose();
+    _stallRetry?.cancel();
     for (final s in _subs) {
       await s.cancel();
     }

--- a/lib/audio/audio_repo.dart
+++ b/lib/audio/audio_repo.dart
@@ -215,18 +215,52 @@ class AudioRepo {
 
   // ── Persistence ───────────────────────────────────────────────────────
 
-  /// Restore the last saved queue + position into mpv WITHOUT auto-playing.
-  /// Returns the loaded state (null if nothing was saved) so callers can
-  /// reflect it in the UI (mini player, expanded player).
-  Future<SavedPlaybackState?> restore() async {
+  /// Wait for mpv's playlist to reach [expected] entries.
+  ///
+  /// Polled rather than awaited on a stream: the queue listenable is a plain
+  /// ValueListenable with no completion signal, and the interesting condition
+  /// is a length rather than an event. Capped, because a queue that never
+  /// arrives must not leave restore suppressed forever — a stale guard would
+  /// stop persisting real changes for the rest of the session.
+  Future<void> _queueSettled(int expected) async {
+    const step = Duration(milliseconds: 50);
+    const limit = Duration(seconds: 5);
+    var waited = Duration.zero;
+    while (waited < limit) {
+      if (handler.queueListenable.value.length >= expected) return;
+      await Future<void>.delayed(step);
+      waited += step;
+    }
+    debugPrint('[audio] queue did not settle at $expected — releasing guard');
+  }
+
+  /// The last saved queue + position, read from disk.
+  ///
+  /// Split from [prepareSaved] because the two have wildly different costs.
+  /// This is a Hive read; that one opens the file in mpv, which resolves a
+  /// stream URL over the network. They used to be one method, so the mini
+  /// player sat empty until a round trip to a CDN had completed — the saved
+  /// track and its position arrived seconds after the app was already on
+  /// screen. Callers show this result immediately and prepare in the
+  /// background.
+  Future<SavedPlaybackState?> loadSaved() async {
+    final saved = await store.load();
+    if (saved == null) return null;
+    _queue = saved.queue;
+    _currentIndex = saved.currentIndex;
+    _sourceLabel = saved.sourceLabel;
+    _sourceRef = saved.sourceRef;
+    return saved;
+  }
+
+  /// Hand the saved queue to mpv, paused and seeked, ready for a tap on play.
+  ///
+  /// [_restoreInProgress] covers exactly this: `prepareQueue` emits
+  /// track-change and queue events before mpv has loaded the file, and
+  /// persisting on those would write position 0 over the saved one.
+  Future<void> prepareSaved(SavedPlaybackState saved) async {
     _restoreInProgress = true;
     try {
-      final saved = await store.load();
-      if (saved == null) return null;
-      _queue = saved.queue;
-      _currentIndex = saved.currentIndex;
-      _sourceLabel = saved.sourceLabel;
-      _sourceRef = saved.sourceRef;
       unawaited(
         sponsorBlock.onTrackChanged(
           saved.queue[saved.currentIndex.clamp(0, saved.queue.length - 1)],
@@ -237,6 +271,13 @@ class AudioRepo {
         saved.currentIndex,
         seekTo: Duration(seconds: saved.positionSec),
       );
+      // prepareQueue returning does not mean mpv has finished building its
+      // playlist. It keeps emitting queue events as the entries land, and
+      // each one drives _onHandlerQueueChanged -> persistAll with a partial
+      // queue and position 0 — which overwrote the very state just restored.
+      // Measured on a device: sixteen writes, the queue growing 15 -> 52,
+      // every one of them stamping pos=0s over a saved 202s.
+      await _queueSettled(saved.queue.length);
       final bridge = _bridge;
       if (bridge != null) {
         bridge.announceQueue(
@@ -244,7 +285,6 @@ class AudioRepo {
           startIndex: saved.currentIndex,
         );
       }
-      return saved;
     } finally {
       _restoreInProgress = false;
     }

--- a/lib/audio/audio_service_bridge.dart
+++ b/lib/audio/audio_service_bridge.dart
@@ -3,6 +3,7 @@
 // or throws, in-app playback is untouched.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:audio_service/audio_service.dart';
 import 'package:flutter/foundation.dart';
@@ -194,6 +195,19 @@ class SunohAudioServiceBridge extends BaseAudioHandler {
     String parentMediaId, [
     Map<String, dynamic>? options,
   ]) async {
+    // Android asks for the "recent" root to decide whether to offer a media
+    // resumption card in Quick Settings — the one that outlives the app being
+    // swiped away and offers to start it again. Answering with nothing opts
+    // out of it, which is what "close the app and it's closed" means.
+    //
+    // Distinct from the browsable root Android Auto uses, so the car's browse
+    // tree is untouched. The cost is that the system can no longer cold-start
+    // playback from that card; the app has to be opened.
+    if (parentMediaId == _kRecentRoot) {
+      debugPrint('[auto] declining the resumption root');
+      return const [];
+    }
+
     final browse = _browse;
     if (browse == null) return const [];
     try {
@@ -258,13 +272,67 @@ class SunohAudioServiceBridge extends BaseAudioHandler {
     }
   }
 
+  /// audio_service's id for the resumption root — `RECENT_ROOT_ID` in its
+  /// AudioService.java. Hardcoded because the plugin does not export it.
+  static const _kRecentRoot = 'recent';
+
+  /// Flush anything that must outlive the process. Set from main once the
+  /// repo exists; the bridge is built before it.
+  Future<void> Function()? onBeforeShutdown;
+
   /// Android fires this when the user swipes the app from the recents list.
-  /// We pause instead of stopping so the queue + saved position stay intact
-  /// in memory + on disk. The OS handles winding down the foreground service
-  /// after we pause (with `androidStopForegroundOnPause: true` in main.dart).
+  ///
+  /// Pausing alone left the process running, because the foreground service
+  /// is configured to survive a pause. Reopening then landed on the same
+  /// screen with the same state, which is not what dismissing an app from
+  /// recents is understood to mean.
+  ///
+  /// So: pause, flush the queue and position to disk, then shut down.
+  /// Deliberately not this class's own [stop] — that seeks to zero, which
+  /// would throw away the resume position the flush just saved.
+  ///
+  /// This shuts down unconditionally. An earlier version skipped the exit
+  /// whenever a media browser had ever queried us, on the theory that a
+  /// connected car should not be taken down with the phone's task. That flag
+  /// was set by the first `getChildren` and never cleared — and the system's
+  /// media browser framework calls it, not only Android Auto — so in practice
+  /// one stale query left the process alive forever, which is precisely the
+  /// bug this method exists to fix. If the car case turns out to matter it
+  /// needs a signal that actually tracks a live connection, not a latch.
   @override
   Future<void> onTaskRemoved() async {
-    debugPrint('[audio-svc] onTaskRemoved — pausing');
-    await pause();
+    debugPrint('[audio-svc] onTaskRemoved — saving and shutting down');
+
+    // Every step is time-boxed. The first version of this awaited each in
+    // turn and never reached the exit: the task is being torn down around us,
+    // and a call that normally returns can simply not come back. A shutdown
+    // path that can hang is worse than one that gives up on a step — the
+    // process staying alive is the exact bug this exists to fix.
+    await _step('pause', pause());
+    if (onBeforeShutdown != null) {
+      await _step('save', onBeforeShutdown!());
+    }
+    await _step('stop', super.stop());
+
+    // Only actually exiting gives a cold start: a stopped service leaves an
+    // empty cached process that Android happily reuses, restoring the very
+    // screen the user just dismissed. Safe here — the UI is gone and the save
+    // above has either finished or had its chance.
+    debugPrint('[audio-svc] exiting');
+    exit(0);
+  }
+
+  /// Await [work], but never for longer than [limit], and never fatally.
+  static Future<void> _step(
+    String name,
+    Future<void> work, {
+    Duration limit = const Duration(seconds: 2),
+  }) async {
+    try {
+      await work.timeout(limit);
+      debugPrint('[audio-svc] shutdown: $name ok');
+    } catch (e) {
+      debugPrint('[audio-svc] shutdown: $name skipped ($e)');
+    }
   }
 }

--- a/lib/audio/download_manager.dart
+++ b/lib/audio/download_manager.dart
@@ -30,6 +30,7 @@ import 'package:path_provider/path_provider.dart';
 import '../api/dto.dart';
 import '../api/stream_resolver.dart';
 import 'download_store.dart';
+import 'hls_download.dart';
 
 /// Snapshot of a single in-flight download. Pushed onto [progressStream]
 /// on every Dio chunk callback (throttled to ~10 Hz to keep the UI
@@ -271,31 +272,48 @@ class DownloadManager implements LocalSourceProvider {
         ext = '.aac';
       } else if (urlForExt.contains('.opus')) {
         ext = '.opus';
-      } else if (urlForExt.contains('.m3u8') || urlForExt.contains('hls')) {
-        throw const _UnsupportedHlsException();
       }
+
+      // HLS is a playlist of segments rather than a file, so it takes a
+      // different path entirely — see hls_download.dart. MPEG-TS is the
+      // container the segments already are; concatenating them needs no
+      // remux.
+      final isHls = urlForExt.contains('.m3u8') || urlForExt.contains('hls');
+      if (isHls) ext = '.ts';
+
       final finalPath = '${entry.localPath}$ext';
       final partPath = '$finalPath.part';
 
       // Download to .part then rename atomically — the resolver checks
       // existence on the final path, so a half-written file is never
       // visible to playback.
-      await _dio.download(
-        url,
-        partPath,
-        cancelToken: cancel,
-        options: Options(responseType: ResponseType.bytes),
-        onReceiveProgress: (received, total) {
-          if (received <= 0) return;
-          _progressEvents.add(
-            DownloadProgress(
-              songId: entry.id,
-              received: received,
-              total: total,
-            ),
-          );
-        },
-      );
+      if (isHls) {
+        await HlsDownloader(_dio).download(
+          masterUrl: _bestHlsUrl(resolved, url),
+          toPath: partPath,
+          cancel: cancel,
+          onProgress: (done, total) => _progressEvents.add(
+            DownloadProgress(songId: entry.id, received: done, total: total),
+          ),
+        );
+      } else {
+        await _dio.download(
+          url,
+          partPath,
+          cancelToken: cancel,
+          options: Options(responseType: ResponseType.bytes),
+          onReceiveProgress: (received, total) {
+            if (received <= 0) return;
+            _progressEvents.add(
+              DownloadProgress(
+                songId: entry.id,
+                received: received,
+                total: total,
+              ),
+            );
+          },
+        );
+      }
 
       final partFile = File(partPath);
       final size = await partFile.length();
@@ -310,11 +328,10 @@ class DownloadManager implements LocalSourceProvider {
       _entries[entry.id] = entry;
       await store.put(entry);
       _entryEvents.add(entry);
-    } on _UnsupportedHlsException {
-      entry = entry.copyWith(
-        state: DownloadState.failed,
-        error: 'HLS streams aren’t downloadable yet',
-      );
+    } on HlsUnsupported catch (e) {
+      // A playlist we genuinely cannot turn into a file — encrypted, empty or
+      // unreadable. The reason reaches the row rather than a bare "failed".
+      entry = entry.copyWith(state: DownloadState.failed, error: e.reason);
       _entries[entry.id] = entry;
       await store.put(entry);
       _entryEvents.add(entry);
@@ -340,8 +357,23 @@ class DownloadManager implements LocalSourceProvider {
   }
 }
 
-class _UnsupportedHlsException implements Exception {
-  const _UnsupportedHlsException();
-  @override
-  String toString() => 'HLS playlists are not single-file downloadable';
+/// The best-quality HLS master among the qualities the API offered.
+///
+/// A download is kept, so it is worth its size in a way a stream on mobile
+/// data is not — this ignores the app's stream-quality setting on purpose.
+///
+/// `auto` and `high` masters both list the top variant (measured on gaana:
+/// ~200 kbps, against ~83 for `medium`), and [HlsDownloader] picks the highest
+/// bandwidth within whichever it is given. Falls back to the resolved URL when
+/// the response carried no alternatives.
+String _bestHlsUrl(ResolvedStream resolved, String fallback) {
+  final urls = resolved.enriched?.mediaUrls ?? const [];
+  for (final wanted in const ['auto', 'high']) {
+    for (final m in urls) {
+      if (m.quality.toLowerCase() == wanted && m.link.contains('.m3u8')) {
+        return m.link;
+      }
+    }
+  }
+  return fallback;
 }

--- a/lib/audio/hls_download.dart
+++ b/lib/audio/hls_download.dart
@@ -1,0 +1,150 @@
+// Downloading an HLS stream as one playable file.
+//
+// Gaana ships its audio as HLS — a playlist of six-second MPEG-TS segments —
+// where saavn ships a single .m4a. Dio can fetch a file; it cannot fetch a
+// playlist, so gaana songs were refused with "HLS streams aren't downloadable
+// yet" and the download action was hidden on every gaana row.
+//
+// It turns out to need no more than this file. MPEG-TS is designed to be
+// concatenated: writing the segments end to end produces a valid stream that
+// mpv plays directly. Verified against a real track before this was written —
+// 55 segments appended came back from ffprobe as `mpegts, aac, 44100 Hz,
+// stereo, 329.5s`, the complete song. No remux, no ffmpeg, no new dependency.
+//
+// Encryption is the case this deliberately does not handle. Gaana's playlists
+// carry no EXT-X-KEY, and rather than half-implement AES-128 HLS against a
+// provider that does not use it, an encrypted playlist is refused with a clear
+// reason. If some provider starts encrypting, this fails loudly instead of
+// writing a file of undecryptable bytes that fails much later at playback.
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+/// Thrown when a playlist cannot be turned into a file. The message reaches
+/// the download row, so it says what is wrong rather than "failed".
+class HlsUnsupported implements Exception {
+  const HlsUnsupported(this.reason);
+  final String reason;
+  @override
+  String toString() => reason;
+}
+
+class HlsDownloader {
+  const HlsDownloader(this._dio);
+  final Dio _dio;
+
+  /// Fetch [masterUrl] and write the whole stream to [toPath].
+  ///
+  /// [onProgress] counts segments rather than bytes: an HLS download has no
+  /// Content-Length for the whole thing, and segments are close enough to
+  /// uniform that "18 of 55" is both honest and smooth. Returns the byte size
+  /// of the finished file.
+  Future<int> download({
+    required String masterUrl,
+    required String toPath,
+    required CancelToken cancel,
+    required void Function(int done, int total) onProgress,
+  }) async {
+    final playlistUrl = await _mediaPlaylistUrl(masterUrl, cancel);
+    final playlist = await _text(playlistUrl, cancel);
+
+    if (playlist.contains('#EXT-X-KEY')) {
+      throw const HlsUnsupported('This track is encrypted and can’t be saved');
+    }
+
+    final segments = _uris(
+      playlist,
+    ).map((u) => Uri.parse(playlistUrl).resolve(u).toString()).toList();
+    if (segments.isEmpty) {
+      throw const HlsUnsupported('This track’s playlist was empty');
+    }
+
+    final file = File(toPath);
+    // Append mode, one open handle for the whole run: reopening per segment
+    // would be dozens of syscalls for no benefit, and a half-written file is
+    // never visible because the caller writes to `.part` and renames.
+    final sink = file.openWrite(mode: FileMode.write);
+    var written = 0;
+    try {
+      for (var i = 0; i < segments.length; i++) {
+        final bytes = await _bytes(segments[i], cancel);
+        sink.add(bytes);
+        written += bytes.length;
+        onProgress(i + 1, segments.length);
+      }
+    } finally {
+      await sink.close();
+    }
+    debugPrint(
+      '[downloads] hls wrote ${segments.length} segments, '
+      '${(written / 1024).round()} KiB',
+    );
+    return written;
+  }
+
+  /// The media playlist to pull segments from.
+  ///
+  /// A master playlist lists variants; a media playlist lists segments. Both
+  /// arrive at this URL depending on the provider, so the shape is detected
+  /// rather than assumed. When it is a master, the highest bandwidth wins:
+  /// a download is kept, so it is worth its size in a way a stream on mobile
+  /// data is not.
+  Future<String> _mediaPlaylistUrl(String masterUrl, CancelToken cancel) async {
+    final text = await _text(masterUrl, cancel);
+    if (!text.contains('#EXT-X-STREAM-INF')) return masterUrl;
+
+    final lines = text.split('\n');
+    var bestBandwidth = -1;
+    String? bestUri;
+    for (var i = 0; i < lines.length; i++) {
+      final line = lines[i].trim();
+      if (!line.startsWith('#EXT-X-STREAM-INF')) continue;
+      final match = RegExp(r'BANDWIDTH=(\d+)').firstMatch(line);
+      final bandwidth = int.tryParse(match?.group(1) ?? '') ?? 0;
+      // The URI is the next line that is neither blank nor a tag.
+      for (var j = i + 1; j < lines.length; j++) {
+        final candidate = lines[j].trim();
+        if (candidate.isEmpty || candidate.startsWith('#')) continue;
+        if (bandwidth > bestBandwidth) {
+          bestBandwidth = bandwidth;
+          bestUri = candidate;
+        }
+        break;
+      }
+    }
+    if (bestUri == null) {
+      throw const HlsUnsupported('This track’s playlist had no streams');
+    }
+    return Uri.parse(masterUrl).resolve(bestUri).toString();
+  }
+
+  /// Playlist lines that are neither blank nor tags — the segment URIs.
+  static List<String> _uris(String playlist) => [
+    for (final line in playlist.split('\n'))
+      if (line.trim().isNotEmpty && !line.trim().startsWith('#')) line.trim(),
+  ];
+
+  Future<String> _text(String url, CancelToken cancel) async {
+    final res = await _dio.get<String>(
+      url,
+      cancelToken: cancel,
+      options: Options(responseType: ResponseType.plain),
+    );
+    final body = res.data;
+    if (body == null || body.isEmpty) {
+      throw const HlsUnsupported('This track’s playlist could not be read');
+    }
+    return body;
+  }
+
+  Future<List<int>> _bytes(String url, CancelToken cancel) async {
+    final res = await _dio.get<List<int>>(
+      url,
+      cancelToken: cancel,
+      options: Options(responseType: ResponseType.bytes),
+    );
+    return res.data ?? const [];
+  }
+}

--- a/lib/audio/local_library.dart
+++ b/lib/audio/local_library.dart
@@ -10,11 +10,14 @@
 // raw MediaStore columns are still separate; this class only holds the result
 // and owns the permission dance.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import '../api/dto.dart';
 import '../api/local_media_channel.dart';
+import '../api/local_sort.dart';
 import 'settings_store.dart';
 
 /// Why the local library is empty, when it is.
@@ -46,6 +49,14 @@ class LocalLibrary extends ChangeNotifier {
 
   FolderRules _rules = const FolderRules();
 
+  LocalSort _sort = LocalSort.dateAdded;
+  bool _sortAscending = false;
+
+  /// How the songs list is ordered. Albums and artists are unaffected —
+  /// inside an album, track order wins regardless (see [sortAlbumTracks]).
+  LocalSort get sort => _sort;
+  bool get sortAscending => _sortAscending;
+
   /// Which folders the library takes music from.
   FolderRules get folderRules => _rules;
 
@@ -63,6 +74,28 @@ class LocalLibrary extends ChangeNotifier {
   /// separate columns, and rebuilding them from already-mapped items would
   /// mean parsing a display string back apart. The scan is cheap on a warm
   /// album-art cache.
+  /// Change the order. No rescan: [songs] sorts what is already in memory.
+  /// Rescan when music is added to or removed from the phone.
+  ///
+  /// Only while there is already a library loaded: a change notification is
+  /// not a reason to ask for storage permission, and scanning before the user
+  /// has opened the library once would be work nobody asked for.
+  void watchDevice() {
+    _channel.onLibraryChanged(() {
+      if (_scan.songs.isEmpty && _status != LocalLibraryStatus.ready) return;
+      debugPrint('[local] device library changed — rescanning');
+      unawaited(load(force: true));
+    });
+  }
+
+  Future<void> setSort(LocalSort sort, {required bool ascending}) async {
+    if (_sort == sort && _sortAscending == ascending) return;
+    _sort = sort;
+    _sortAscending = ascending;
+    notifyListeners();
+    await _settings.saveLocalSort(sort.key, ascending: ascending);
+  }
+
   Future<void> setFolderRules(FolderRules rules) async {
     if (rules.sameAs(_rules)) return;
     _rules = rules;
@@ -76,8 +109,67 @@ class LocalLibrary extends ChangeNotifier {
 
   LocalScan _scan = const LocalScan.empty();
 
+  /// Genre and folder groupings, built once per scan.
+  ///
+  /// Derived rather than scanned: both are a regroup of songs we already have,
+  /// and doing it on every read would put an O(n) walk inside `build`.
+  List<LocalCollection> _genres = const [];
+  List<LocalCollection> _folderGroups = const [];
+
+  /// Songs grouped by tag genre. Empty below Android 11, where MediaStore has
+  /// no GENRE column at all — the tab hides itself rather than showing one
+  /// bogus "Unknown" bucket holding the entire library.
+  List<LocalCollection> get genres => _genres;
+
+  /// Songs grouped by the folder they sit in — the way a library organised on
+  /// disk rather than by tags is actually navigated.
+  List<LocalCollection> get folderGroups => _folderGroups;
+
+  void _regroup() {
+    final byGenre = <String, List<FeedItem>>{};
+    final byFolder = <String, List<FeedItem>>{};
+    for (final song in _scan.songs) {
+      final genre = _scan.meta[song.id]?.genre;
+      if (genre != null && genre.isNotEmpty) {
+        (byGenre[genre] ??= []).add(song);
+      }
+      final folder = folderOf(song.url ?? '');
+      if (folder.isNotEmpty) (byFolder[folder] ??= []).add(song);
+    }
+    _genres = [
+      for (final e in byGenre.entries)
+        LocalCollection(
+          id: e.key,
+          name: e.key,
+          subtitle: '${e.value.length} songs',
+          songs: e.value,
+        ),
+    ]..sort((a, b) => b.songs.length.compareTo(a.songs.length));
+    _folderGroups = [
+      for (final e in byFolder.entries)
+        LocalCollection(
+          id: e.key,
+          name: folderNameOf(e.key),
+          subtitle: folderLocation(e.key),
+          songs: e.value,
+        ),
+    ]..sort((a, b) => a.name.toLowerCase().compareTo(b.name.toLowerCase()));
+  }
+
   /// Every on-device track, newest first.
-  List<FeedItem> get songs => _scan.songs;
+  /// Sorted on read rather than at scan time: changing the order should not
+  /// cost a MediaStore query, and the scan's own order is the raw material
+  /// every ordering is derived from.
+  List<FeedItem> get songs => sortLocalSongs(
+    _scan.songs,
+    _scan.meta,
+    by: _sort,
+    ascending: _sortAscending,
+  );
+
+  /// Unsorted, in scan order. For anything that wants "most recently added"
+  /// without inheriting whatever the user picked.
+  List<FeedItem> get songsByDateAdded => _scan.songs;
   List<LocalCollection> get albums => _scan.albums;
   List<LocalCollection> get artists => _scan.artists;
 
@@ -115,7 +207,11 @@ class LocalLibrary extends ChangeNotifier {
     if (_status == LocalLibraryStatus.scanning) return;
     _set(LocalLibraryStatus.scanning);
     _rules = await _settings.loadFolderRules();
+    final (sortKey, asc) = await _settings.loadLocalSort();
+    _sort = LocalSortLabel.fromKey(sortKey);
+    _sortAscending = asc;
     _scan = await _channel.scan(rules: _rules);
+    _regroup();
     _set(LocalLibraryStatus.ready);
   }
 

--- a/lib/audio/settings_store.dart
+++ b/lib/audio/settings_store.dart
@@ -21,6 +21,7 @@ class SavedAppearance {
     this.tintFromArt,
     this.tintIntensity,
     this.theme,
+    this.showCast,
   });
   final int? accentValue; // ARGB int (Color.value)
   final String? density; // 'compact' / 'regular' / 'comfy'
@@ -30,6 +31,9 @@ class SavedAppearance {
   /// predate light mode, which resolve to dark: the app shipped dark-only, so
   /// that is what an existing user already has on screen.
   final String? theme;
+
+  /// Null on installs that predate the toggle, which resolve to shown.
+  final bool? showCast;
 }
 
 class SavedPlayback {
@@ -78,6 +82,10 @@ class SettingsStore {
   static const _kTheme = 'appearance.theme';
   static const _kTintIntensity = 'appearance.tint_intensity';
 
+  /// Whether the Cast button is shown. Appearance rather than playback: it
+  /// changes what the UI offers, not how anything plays.
+  static const _kShowCast = 'appearance.show_cast';
+
   // Playback
   static const _kStreamQuality = 'playback.stream_quality';
   // `_kCrossfadeSec` retired with the crossfade feature 2026-05-26 — old
@@ -107,6 +115,12 @@ class SettingsStore {
   /// different phones, so one device's folder choice is meaningless on another
   /// and would silently hide the wrong music.
   static const _kFolderRules = 'local.folder_rules';
+
+  /// How the on-device library is ordered. Per-device like the folder rules
+  /// and for the same reason — it describes this phone's library, not the
+  /// user's taste — so it is not synced either.
+  static const _kLocalSort = 'local.sort';
+  static const _kLocalSortAsc = 'local.sort_ascending';
 
   static const _kSyncTree = 'sync.tree_uri';
   static const _kSyncKey = 'sync.key';
@@ -211,6 +225,7 @@ class SettingsStore {
     bool? tintFromArt,
     double? tintIntensity,
     Object? theme, // SunohTheme; caller passes the enum
+    bool? showCast,
   }) async {
     final box = await _box();
     final map = <String, dynamic>{};
@@ -228,6 +243,7 @@ class SettingsStore {
     if (tintFromArt != null) map[_kTintFromArt] = tintFromArt;
     if (tintIntensity != null) map[_kTintIntensity] = tintIntensity;
     if (theme != null) map[_kTheme] = theme.toString().split('.').last;
+    if (showCast != null) map[_kShowCast] = showCast;
     if (map.isEmpty) return;
     await box.putAll(map);
     await box.flush();
@@ -240,6 +256,7 @@ class SettingsStore {
       return SavedAppearance(
         accentValue: box.get(_kAccent) as int?,
         theme: box.get(_kTheme) as String?,
+        showCast: box.get(_kShowCast) as bool?,
         density: box.get(_kDensity) as String?,
         tintFromArt: box.get(_kTintFromArt) as bool?,
         tintIntensity: (box.get(_kTintIntensity) as num?)?.toDouble(),
@@ -373,6 +390,7 @@ extension SyncSettings on SettingsStore {
     'appearance.tint_from_art',
     'appearance.tint_intensity',
     'appearance.theme',
+    'appearance.show_cast',
     'playback.stream_quality',
     'playback.repeat_mode',
     'playback.languages',
@@ -391,6 +409,29 @@ extension SyncSettings on SettingsStore {
     } catch (e) {
       debugPrint('[settings-store] loadFolderRules failed: $e');
       return const FolderRules();
+    }
+  }
+
+  Future<(String?, bool)> loadLocalSort() async {
+    try {
+      final box = await _box();
+      final key = box.get(SettingsStore._kLocalSort);
+      final asc = box.get(SettingsStore._kLocalSortAsc);
+      return (key is String ? key : null, asc is bool ? asc : false);
+    } catch (e) {
+      debugPrint('[settings-store] loadLocalSort failed: $e');
+      return (null, false);
+    }
+  }
+
+  Future<void> saveLocalSort(String key, {required bool ascending}) async {
+    try {
+      final box = await _box();
+      await box.put(SettingsStore._kLocalSort, key);
+      await box.put(SettingsStore._kLocalSortAsc, ascending);
+      await box.flush();
+    } catch (e) {
+      debugPrint('[settings-store] saveLocalSort failed: $e');
     }
   }
 

--- a/lib/cast/cast_button.dart
+++ b/lib/cast/cast_button.dart
@@ -51,6 +51,9 @@ class _CastButtonState extends ConsumerState<CastButton> {
     final c = s.colors;
     final accent = s.resolvedAccent;
     final connected = s.isCasting;
+    // Hidden by preference — but never while a cast is actually running, or
+    // there would be no way back off the TV except from the notification.
+    if (!s.showCastButton && !connected) return const SizedBox.shrink();
     return IconBtn(
       icon: connected
           ? SolarIconsBold.screencast

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -282,6 +282,10 @@ Future<void> main() async {
     _tryWireAudioService(handler, autoBrowse).then((bridge) {
       if (bridge != null) {
         repo.attachBridge(bridge);
+        // Swiping the app from recents shuts the process down, and the queue
+        // and position have to reach disk before it goes. The bridge is built
+        // before the repo exists, so the hook is handed over here.
+        bridge.onBeforeShutdown = repo.persistAll;
       }
     }),
   );

--- a/lib/overlays/hero_menu_sheet.dart
+++ b/lib/overlays/hero_menu_sheet.dart
@@ -172,10 +172,10 @@ class _HeroMenuSheet extends ConsumerWidget {
               ),
             // Bulk download for albums/playlists — fans every track out
             // to the download manager, capped at 2 concurrent by the
-            // manager's own queue. Hidden for gaana (HLS, can't single-
-            // file save) and for entity kinds without a flat song list
-            // (artist, etc — caller passes [] or omits `songs`).
-            if (entity.source != 'gaana' && songs.isNotEmpty)
+            // manager's own queue. Hidden only for entity kinds without a
+            // flat song list (artist, etc — caller passes [] or omits
+            // `songs`); gaana's HLS is handled in audio/hls_download.dart.
+            if (songs.isNotEmpty)
               _HeroMenuRow(
                 icon: SolarIconsOutline.downloadMinimalistic,
                 label: 'Download all (${songs.length})',

--- a/lib/overlays/local_sort_sheet.dart
+++ b/lib/overlays/local_sort_sheet.dart
@@ -1,0 +1,115 @@
+// How to order the on-device songs list.
+//
+// A field and a direction, chosen separately, because they are separate
+// questions: "by artist" and "Z to A" do not belong in one flat list of ten
+// options where half are permutations of the other half.
+//
+// The direction is worded per field — "Newest first" rather than
+// "Descending" — since ascending means nothing until you know what is being
+// sorted.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:solar_icons/solar_icons.dart';
+
+import '../api/local_sort.dart';
+import '../providers/app_state_provider.dart';
+import '../providers/local_library_provider.dart';
+import '../theme/tokens.dart';
+import 'sheet.dart';
+
+Future<void> showLocalSortSheet(BuildContext context) =>
+    showSunohSheet<void>(context, builder: (_) => const _LocalSortSheet());
+
+class _LocalSortSheet extends ConsumerWidget {
+  const _LocalSortSheet();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final c = ref.watch(appStateProvider).colors;
+    final lib = ref.watch(localLibraryProvider);
+
+    return SunohSheet(
+      icon: SolarIconsOutline.sort,
+      title: 'Sort songs',
+      subtitle: 'Albums always play in track order',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (final option in LocalSort.values)
+            _Row(
+              label: option.label,
+              selected: lib.sort == option,
+              colors: c,
+              onTap: () => lib.setSort(option, ascending: lib.sortAscending),
+            ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 14, 16, 6),
+            child: Text(
+              'ORDER',
+              style: SunohType.sans(
+                fontSize: 11,
+                color: c.fgMute,
+                letterSpacing: 1.4,
+              ),
+            ),
+          ),
+          _Row(
+            label: lib.sort.descendingLabel,
+            selected: !lib.sortAscending,
+            colors: c,
+            onTap: () => lib.setSort(lib.sort, ascending: false),
+          ),
+          _Row(
+            label: lib.sort.ascendingLabel,
+            selected: lib.sortAscending,
+            colors: c,
+            onTap: () => lib.setSort(lib.sort, ascending: true),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Row extends StatelessWidget {
+  const _Row({
+    required this.label,
+    required this.selected,
+    required this.colors,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final SunohColors colors;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    return GestureDetector(
+      onTap: onTap,
+      behavior: HitTestBehavior.opaque,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                label,
+                style: SunohType.sans(
+                  fontSize: 14,
+                  fontWeight: selected ? FontWeight.w600 : FontWeight.w400,
+                  color: selected ? c.fg : c.fgDim,
+                ),
+              ),
+            ),
+            if (selected)
+              Icon(SolarIconsBold.checkCircle, size: 17, color: c.accent),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/overlays/track_menu_sheet.dart
+++ b/lib/overlays/track_menu_sheet.dart
@@ -267,16 +267,12 @@ class _TrackMenuSheet extends ConsumerWidget {
                 },
                 colors: c,
               ),
-            // Download / Downloaded / Remove download — only saavn songs
-            // are downloadable today (gaana ships HLS playlists which we
-            // can't single-file save). The row hides entirely for gaana.
+            // Download / Downloaded / Remove download.
             //
-            // Some album/playlist detail responses don't restamp each
-            // song with its `source`, so fall back to the parent's
-            // sourceRef.source — otherwise a song fetched via gaana
-            // would show as downloadable because its own source is null.
-            if (_effectiveSource(song, sourceRef) != 'gaana')
-              _DownloadRow(song: song, colors: c),
+            // Gaana used to be excluded here because it ships HLS playlists
+            // rather than a file. It is downloadable now — the segments are
+            // concatenated into one MPEG-TS, see audio/hls_download.dart.
+            _DownloadRow(song: song, colors: c),
             if (sourceRef != null && sourceRef!.kind != 'artist')
               _MenuRow(
                 icon: sourceRef!.kind == 'album'
@@ -468,12 +464,6 @@ class _MenuRow extends StatelessWidget {
       ),
     );
   }
-}
-
-String? _effectiveSource(FeedItem song, DetailRef? sourceRef) {
-  final s = (song.source ?? '').trim();
-  if (s.isNotEmpty) return s;
-  return sourceRef?.source;
 }
 
 /// The Download row in the track-action sheet. Renders four states based

--- a/lib/providers/local_library_provider.dart
+++ b/lib/providers/local_library_provider.dart
@@ -12,6 +12,10 @@ import '../audio/local_library.dart';
 
 final localLibraryProvider = ChangeNotifierProvider<LocalLibrary>((ref) {
   final library = LocalLibrary();
+  // Rescan when music is copied onto or removed from the phone, so the
+  // library keeps up without a pull-to-refresh. Guarded inside so it only
+  // acts once there is a library to keep up to date.
+  library.watchDevice();
   // Scan only if access is already granted — never prompt from here. This
   // provider is watched by the Library tab's device row, and raising a system
   // permission dialog because someone opened Library is both startling and

--- a/lib/screens/detail_screens.dart
+++ b/lib/screens/detail_screens.dart
@@ -1017,11 +1017,6 @@ class AlbumLikeBodyState extends ConsumerState<AlbumLikeBody> {
                       final isHere =
                           live.apiSourceRef?.kind == kind &&
                           live.apiSourceRef?.id == id;
-                      // Bulk-download surfaces (the heart-row icon + the
-                      // hero-menu "Download all") only matter for saavn
-                      // sources. Gaana songs are HLS, which we can't
-                      // single-file save yet.
-                      final isGaana = widget.sourceRef.source == 'gaana';
                       final dlEntries = ref
                           .watch(downloadEntriesProvider)
                           .asData
@@ -1033,7 +1028,6 @@ class AlbumLikeBodyState extends ConsumerState<AlbumLikeBody> {
                                 if (e.state == DownloadState.done) e.id,
                             };
                       final allDownloaded =
-                          !isGaana &&
                           songs.isNotEmpty &&
                           songs.every((sg) => dlIds.contains(sg.id));
                       return _HeroActions(
@@ -1077,7 +1071,7 @@ class AlbumLikeBodyState extends ConsumerState<AlbumLikeBody> {
                           if (!s.shuffle) s.toggleShuffle();
                         },
                         onLike: () => s.toggleSaved(heroItem),
-                        onDownload: isGaana || songs.isEmpty
+                        onDownload: songs.isEmpty
                             ? null
                             : () {
                                 ref

--- a/lib/screens/local_library_lists.dart
+++ b/lib/screens/local_library_lists.dart
@@ -1,0 +1,242 @@
+// The lists the device-library tabs render: songs, collections, the empty
+// state, and the search field.
+//
+// Split from local_library_screen.dart, which was carrying the screen's
+// scaffold and all of its content in one file. The screen decides what to
+// show; these know how to draw it.
+
+part of 'local_library_screen.dart';
+
+class _SongList extends StatelessWidget {
+  const _SongList({
+    required this.songs,
+    required this.state,
+    required this.colors,
+  });
+  final List<FeedItem> songs;
+  final AppState state;
+  final SunohColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    // Lazy: a device library runs to thousands of tracks, and an eager Column
+    // would build and lay out every one of them.
+    return ListView.builder(
+      padding: const EdgeInsets.only(top: 8, bottom: 140),
+      itemCount: songs.length,
+      itemBuilder: (context, i) => LocalTrackRow(
+        song: songs[i],
+        colors: colors,
+        onTap: () =>
+            state.playApiQueue(songs, i, sourceLabel: 'ON THIS DEVICE'),
+      ),
+    );
+  }
+}
+
+class _CollectionList extends StatelessWidget {
+  const _CollectionList({
+    required this.collections,
+    required this.album,
+    required this.colors,
+  });
+  final List<LocalCollection> collections;
+  final bool album;
+  final SunohColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      padding: const EdgeInsets.only(top: 8, bottom: 140),
+      itemCount: collections.length,
+      itemBuilder: (context, i) {
+        final col = collections[i];
+        return GestureDetector(
+          onTap: () => context.openLocalCollection(col.id, album: album),
+          behavior: HitTestBehavior.opaque,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(20, 6, 20, 6),
+            child: Row(
+              children: [
+                SunohArt(
+                  id: col.id,
+                  size: 48,
+                  // Artists read as circles throughout the app; albums square.
+                  radius: album ? 8 : 999,
+                  imageUrl: col.artwork,
+                  shadow: false,
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        col.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: SunohType.sans(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
+                          color: colors.fg,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        col.subtitle ?? '${col.songs.length} songs',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: SunohType.sans(
+                          fontSize: 12,
+                          color: colors.fgMute,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+/// The ways this screen can be empty, each with the action that fixes it.
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.library, required this.colors});
+  final LocalLibrary library;
+  final SunohColors colors;
+
+  @override
+  Widget build(BuildContext context) {
+    final (title, body, action, onTap) = switch (library.status) {
+      LocalLibraryStatus.denied => (
+        'Access needed',
+        'sunoh needs permission to read audio files on this device.',
+        'Grant access',
+        () => library.load(force: true),
+      ),
+      LocalLibraryStatus.permanentlyDenied => (
+        'Access blocked',
+        'Audio access was turned off for sunoh. Enable it in system '
+            'settings to see music stored on this device.',
+        'Open settings',
+        library.openSettings,
+      ),
+      LocalLibraryStatus.scanning => (
+        'Scanning…',
+        'Reading music stored on this device.',
+        null,
+        null,
+      ),
+      _ => (
+        'No music on this device',
+        'Copy some audio files onto the phone and they will show up here.',
+        'Scan again',
+        () => library.load(force: true),
+      ),
+    };
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(32, 80, 32, 40),
+      child: Column(
+        children: [
+          Icon(SolarIconsOutline.smartphone, size: 34, color: colors.fgMute),
+          const SizedBox(height: 16),
+          Text(
+            title,
+            textAlign: TextAlign.center,
+            style: SunohType.heading(fontSize: 18, color: colors.fg),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            body,
+            textAlign: TextAlign.center,
+            style: SunohType.sans(
+              fontSize: 13,
+              color: colors.fgMute,
+              height: 1.5,
+            ),
+          ),
+          if (action != null && onTap != null) ...[
+            const SizedBox(height: 20),
+            GestureDetector(
+              onTap: onTap,
+              child: Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 18,
+                  vertical: 10,
+                ),
+                decoration: squircleDecoration(
+                  radius: 999,
+                  color: colors.accent,
+                ),
+                child: Text(
+                  action,
+                  style: SunohType.sans(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: colors.onAccent,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+/// Search across the whole device library, replacing the tabs while open.
+class _SearchField extends StatelessWidget {
+  const _SearchField({
+    required this.controller,
+    required this.colors,
+    required this.onChanged,
+  });
+
+  final TextEditingController controller;
+  final SunohColors colors;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 4, 20, 12),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 2),
+        decoration: squircleDecoration(
+          radius: 999,
+          color: c.surface,
+          borderColor: c.line,
+        ),
+        child: Row(
+          children: [
+            Icon(SolarIconsOutline.magnifier, size: 16, color: c.fgMute),
+            const SizedBox(width: 10),
+            Expanded(
+              child: TextField(
+                controller: controller,
+                autofocus: true,
+                onChanged: onChanged,
+                style: SunohType.sans(fontSize: 14, color: c.fg),
+                decoration: InputDecoration(
+                  hintText: 'Search this device',
+                  hintStyle: SunohType.sans(fontSize: 14, color: c.fgMute),
+                  border: InputBorder.none,
+                  isDense: true,
+                  contentPadding: const EdgeInsets.symmetric(vertical: 12),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/local_library_screen.dart
+++ b/lib/screens/local_library_screen.dart
@@ -18,6 +18,7 @@ import 'package:solar_icons/solar_icons.dart';
 import '../api/dto.dart';
 import '../api/local_media_channel.dart';
 import '../audio/local_library.dart';
+import '../overlays/local_sort_sheet.dart';
 import '../providers/app_state_provider.dart';
 import '../providers/local_library_provider.dart';
 import '../router/router.dart';
@@ -28,7 +29,26 @@ import '../widgets/top_tabs.dart';
 import '../widgets/ui.dart';
 import 'local_track_row.dart';
 
-const List<String> _kTabs = ['Songs', 'Albums', 'Artists'];
+/// The tab content. See the file header there.
+part 'local_library_lists.dart';
+
+const String _kSongs = 'Songs';
+const String _kAlbums = 'Albums';
+const String _kArtists = 'Artists';
+const String _kGenres = 'Genres';
+const String _kFolders = 'Folders';
+
+/// Genres and Folders only appear when there is something in them. MediaStore
+/// has no GENRE column below Android 11, and a library of loose files in one
+/// directory has nothing to browse by folder — an always-present tab holding
+/// one bucket is worse than no tab.
+List<String> _tabsFor(LocalLibrary lib) => [
+  _kSongs,
+  _kAlbums,
+  _kArtists,
+  if (lib.genres.isNotEmpty) _kGenres,
+  if (lib.folderGroups.length > 1) _kFolders,
+];
 
 class LocalLibraryScreen extends ConsumerStatefulWidget {
   const LocalLibraryScreen({super.key});
@@ -38,7 +58,9 @@ class LocalLibraryScreen extends ConsumerStatefulWidget {
 
 class _LocalLibraryScreenState extends ConsumerState<LocalLibraryScreen> {
   final PageController _pages = PageController();
+  final TextEditingController _search = TextEditingController();
   int _index = 0;
+  bool _searching = false;
 
   @override
   void initState() {
@@ -54,8 +76,16 @@ class _LocalLibraryScreenState extends ConsumerState<LocalLibraryScreen> {
 
   @override
   void dispose() {
+    _search.dispose();
     _pages.dispose();
     super.dispose();
+  }
+
+  void _toggleSearch() {
+    setState(() {
+      _searching = !_searching;
+      if (!_searching) _search.clear();
+    });
   }
 
   void _select(int i) {
@@ -74,38 +104,71 @@ class _LocalLibraryScreenState extends ConsumerState<LocalLibraryScreen> {
     final c = s.colors;
     final lib = ref.watch(localLibraryProvider);
 
+    final tabs = _tabsFor(lib);
+    final index = _index.clamp(0, tabs.length - 1);
+    final query = _searching ? _search.text.trim() : '';
+
     return ColoredBox(
       color: c.bg,
       child: Column(
         children: [
-          _Header(library: lib, colors: c),
-          if (lib.hasMusic)
-            SunohTabs(
-              tabs: _kTabs,
-              active: _kTabs[_index],
+          _Header(
+            library: lib,
+            colors: c,
+            searching: _searching,
+            onToggleSearch: _toggleSearch,
+          ),
+          if (_searching)
+            _SearchField(
+              controller: _search,
               colors: c,
-              onChange: (t) => _select(_kTabs.indexOf(t)),
+              onChanged: (_) => setState(() {}),
+            ),
+          if (lib.hasMusic && !_searching)
+            SunohTabs(
+              tabs: tabs,
+              active: tabs[index],
+              colors: c,
+              onChange: (t) => _select(tabs.indexOf(t)),
             ),
           Expanded(
             child: !lib.hasMusic
                 ? SingleChildScrollView(
                     child: _EmptyState(library: lib, colors: c),
                   )
+                // Search replaces the tabs rather than filtering within one:
+                // looking for a song by name should not require first knowing
+                // whether it lives under Albums or Artists.
+                : _searching
+                ? _SongList(songs: lib.search(query), state: s, colors: c)
                 : PageView(
                     controller: _pages,
                     onPageChanged: (i) => setState(() => _index = i),
                     children: [
-                      _SongList(songs: lib.songs, state: s, colors: c),
-                      _CollectionList(
-                        collections: lib.albums,
-                        album: true,
-                        colors: c,
-                      ),
-                      _CollectionList(
-                        collections: lib.artists,
-                        album: false,
-                        colors: c,
-                      ),
+                      for (final tab in tabs)
+                        switch (tab) {
+                          _kAlbums => _CollectionList(
+                            collections: lib.albums,
+                            album: true,
+                            colors: c,
+                          ),
+                          _kArtists => _CollectionList(
+                            collections: lib.artists,
+                            album: false,
+                            colors: c,
+                          ),
+                          _kGenres => _CollectionList(
+                            collections: lib.genres,
+                            album: true,
+                            colors: c,
+                          ),
+                          _kFolders => _CollectionList(
+                            collections: lib.folderGroups,
+                            album: true,
+                            colors: c,
+                          ),
+                          _ => _SongList(songs: lib.songs, state: s, colors: c),
+                        },
                     ],
                   ),
           ),
@@ -116,9 +179,16 @@ class _LocalLibraryScreenState extends ConsumerState<LocalLibraryScreen> {
 }
 
 class _Header extends StatelessWidget {
-  const _Header({required this.library, required this.colors});
+  const _Header({
+    required this.library,
+    required this.colors,
+    required this.searching,
+    required this.onToggleSearch,
+  });
   final LocalLibrary library;
   final SunohColors colors;
+  final bool searching;
+  final VoidCallback onToggleSearch;
 
   @override
   Widget build(BuildContext context) {
@@ -157,200 +227,22 @@ class _Header extends StatelessWidget {
             )
           else ...[
             IconBtn(
+              icon: SolarIconsOutline.magnifier,
+              color: searching ? c.accent : c.fgDim,
+              size: 18,
+              onTap: onToggleSearch,
+            ),
+            IconBtn(
+              icon: SolarIconsOutline.sort,
+              color: c.fgDim,
+              size: 18,
+              onTap: () => showLocalSortSheet(context),
+            ),
+            IconBtn(
               icon: SolarIconsOutline.folder,
               color: c.fgDim,
               size: 18,
               onTap: () => context.openLocalFolders(),
-            ),
-            IconBtn(
-              icon: SolarIconsOutline.refresh,
-              color: c.fgDim,
-              size: 18,
-              onTap: () => library.load(force: true),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _SongList extends StatelessWidget {
-  const _SongList({
-    required this.songs,
-    required this.state,
-    required this.colors,
-  });
-  final List<FeedItem> songs;
-  final AppState state;
-  final SunohColors colors;
-
-  @override
-  Widget build(BuildContext context) {
-    // Lazy: a device library runs to thousands of tracks, and an eager Column
-    // would build and lay out every one of them.
-    return ListView.builder(
-      padding: const EdgeInsets.only(top: 8, bottom: 140),
-      itemCount: songs.length,
-      itemBuilder: (context, i) => LocalTrackRow(
-        song: songs[i],
-        colors: colors,
-        onTap: () =>
-            state.playApiQueue(songs, i, sourceLabel: 'ON THIS DEVICE'),
-      ),
-    );
-  }
-}
-
-class _CollectionList extends StatelessWidget {
-  const _CollectionList({
-    required this.collections,
-    required this.album,
-    required this.colors,
-  });
-  final List<LocalCollection> collections;
-  final bool album;
-  final SunohColors colors;
-
-  @override
-  Widget build(BuildContext context) {
-    return ListView.builder(
-      padding: const EdgeInsets.only(top: 8, bottom: 140),
-      itemCount: collections.length,
-      itemBuilder: (context, i) {
-        final col = collections[i];
-        return GestureDetector(
-          onTap: () => context.openLocalCollection(col.id, album: album),
-          behavior: HitTestBehavior.opaque,
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(20, 6, 20, 6),
-            child: Row(
-              children: [
-                SunohArt(
-                  id: col.id,
-                  size: 48,
-                  // Artists read as circles throughout the app; albums square.
-                  radius: album ? 8 : 999,
-                  imageUrl: col.artwork,
-                  shadow: false,
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        col.name,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: SunohType.sans(
-                          fontSize: 14,
-                          fontWeight: FontWeight.w500,
-                          color: colors.fg,
-                        ),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        col.subtitle ?? '${col.songs.length} songs',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: SunohType.sans(
-                          fontSize: 12,
-                          color: colors.fgMute,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      },
-    );
-  }
-}
-
-/// The ways this screen can be empty, each with the action that fixes it.
-class _EmptyState extends StatelessWidget {
-  const _EmptyState({required this.library, required this.colors});
-  final LocalLibrary library;
-  final SunohColors colors;
-
-  @override
-  Widget build(BuildContext context) {
-    final (title, body, action, onTap) = switch (library.status) {
-      LocalLibraryStatus.denied => (
-        'Access needed',
-        'sunoh needs permission to read audio files on this device.',
-        'Grant access',
-        () => library.load(force: true),
-      ),
-      LocalLibraryStatus.permanentlyDenied => (
-        'Access blocked',
-        'Audio access was turned off for sunoh. Enable it in system '
-            'settings to see music stored on this device.',
-        'Open settings',
-        library.openSettings,
-      ),
-      LocalLibraryStatus.scanning => (
-        'Scanning…',
-        'Reading music stored on this device.',
-        null,
-        null,
-      ),
-      _ => (
-        'No music on this device',
-        'Copy some audio files onto the phone and they will show up here.',
-        'Scan again',
-        () => library.load(force: true),
-      ),
-    };
-
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(32, 80, 32, 40),
-      child: Column(
-        children: [
-          Icon(SolarIconsOutline.smartphone, size: 34, color: colors.fgMute),
-          const SizedBox(height: 16),
-          Text(
-            title,
-            textAlign: TextAlign.center,
-            style: SunohType.heading(fontSize: 18, color: colors.fg),
-          ),
-          const SizedBox(height: 8),
-          Text(
-            body,
-            textAlign: TextAlign.center,
-            style: SunohType.sans(
-              fontSize: 13,
-              color: colors.fgMute,
-              height: 1.5,
-            ),
-          ),
-          if (action != null && onTap != null) ...[
-            const SizedBox(height: 20),
-            GestureDetector(
-              onTap: onTap,
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 18,
-                  vertical: 10,
-                ),
-                decoration: squircleDecoration(
-                  radius: 999,
-                  color: colors.accent,
-                ),
-                child: Text(
-                  action,
-                  style: SunohType.sans(
-                    fontSize: 13,
-                    fontWeight: FontWeight.w600,
-                    color: colors.onAccent,
-                  ),
-                ),
-              ),
             ),
           ],
         ],

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -135,6 +135,15 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 colors: c,
               ),
               _ToggleRow(
+                label: 'Show Cast button',
+                summary:
+                    'The cast icon beside the player controls. Turn it off if '
+                    'you have nothing to cast to.',
+                value: s.showCastButton,
+                onChange: s.setShowCastButton,
+                colors: c,
+              ),
+              _ToggleRow(
                 label: 'Skip non-music parts',
                 summary:
                     'Uses SponsorBlock to jump sponsor reads, intros and '

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -163,6 +163,7 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
           );
         }
         if (app.tintFromArt != null) tintFromArt = app.tintFromArt!;
+        if (app.showCast != null) showCastButton = app.showCast!;
         final savedTheme = app.theme;
         if (savedTheme != null) {
           for (final t in SunohTheme.values) {
@@ -239,7 +240,7 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
     final repo = audioRepo;
     if (repo == null) return;
     try {
-      final saved = await repo.restore();
+      final saved = await repo.loadSaved();
       if (saved == null) return;
       final song = saved.queue[saved.currentIndex];
       apiSourceLabel = saved.sourceLabel;
@@ -259,6 +260,11 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
       _restoredPositionGuard = saved.positionSec;
       notifyListeners();
       debugPrint('[audio] restored "${song.title}" @ ${saved.positionSec}s');
+      // Only now hand it to mpv. Loading the file resolves a stream URL over
+      // the network, and the UI has no reason to wait on that — everything
+      // above is already on screen, and the engine just has to be ready
+      // before the user taps play.
+      unawaited(repo.prepareSaved(saved));
     } catch (e) {
       debugPrint('[audio] restore failed: $e');
     }
@@ -381,11 +387,21 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
   /// When true, the moment the active track is the last in the queue the
   /// player fires a radio_station prime seeded by it and appends the
   /// returned songs. Off by default; persisted in settings.
-  bool endlessAutoplay = false;
+  /// On by default: a queue that ends in silence reads as the app stopping
+  /// working, and seeding a radio is the behaviour people expect from every
+  /// other music app. Saved installs keep whatever they already chose.
+  bool endlessAutoplay = true;
 
   /// Skip non-music segments (sponsor reads, intros/outros, talking
   /// sections) on YouTube tracks using community SponsorBlock data.
   bool sponsorBlockEnabled = true;
+
+  /// Whether the Cast button appears at all.
+  ///
+  /// Visible by default — hiding a feature people paid attention to find is
+  /// the wrong default. The toggle exists for people with no cast devices,
+  /// for whom the button is permanent clutter beside the transport controls.
+  bool showCastButton = true;
 
   /// Explicit YouTube region / interface language, or empty for auto.
   /// `gl` decides which charts and home rows YouTube returns, so this is
@@ -1332,6 +1348,16 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
 
   /// Mirror a FeedItem into the legacy Track stub the player UI reads from.
   void _applySong(FeedItem song) {
+    // Re-applying the track that is already current is not a track change.
+    //
+    // `prepareQueue` emits a track-change event before mpv has loaded the
+    // file, so restoring a saved session called this twice for the same song:
+    // once from the restore itself, once from that event. The second call ran
+    // the reset below and wiped the restored position back to zero, taking the
+    // guard with it — so the scrubber sat empty until mpv finished resolving a
+    // stream URL and reported a real position, seconds later. Measured: 122s
+    // at +400ms, 0 at +800ms, 122 again only at +2800ms.
+    final sameTrack = currentApiSong?.id == song.id;
     currentApiSong = song;
     // Artist fallback chain: artists[].name → subtitle → empty (let UI
     // hide). The old "Unknown artist" literal was the wrong default for
@@ -1360,15 +1386,17 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
       duration: durSec,
       plays: song.playCount ?? '',
     );
-    // mpv will report fresh duration as the next file loads; clear the
-    // stale value so the player doesn't briefly show the previous track's
-    // duration for the new one.
-    _engineDurationSec = 0;
-    position = 0;
-    // Track change invalidates any pending restore guard — we're past the
-    // restored track now and subsequent 0-reports from mpv (e.g. a new
-    // track loading paused) shouldn't be filtered.
-    _restoredPositionGuard = 0;
+    if (!sameTrack) {
+      // mpv will report fresh duration as the next file loads; clear the
+      // stale value so the player doesn't briefly show the previous track's
+      // duration for the new one.
+      _engineDurationSec = 0;
+      position = 0;
+      // A real track change invalidates any pending restore guard — we're
+      // past the restored track now and subsequent 0-reports from mpv (e.g. a
+      // new track loading paused) shouldn't be filtered.
+      _restoredPositionGuard = 0;
+    }
     _refreshExtractedAccent(song.artwork);
     // Episode resume: when an episode becomes active and we have a
     // saved position for it, seek there. The seek queues against
@@ -2148,6 +2176,13 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
     // immediately so the queue extends without waiting for the next
     // track-change event (which only fires on advance).
     if (enabled) _maybeAutoplayPrime();
+  }
+
+  Future<void> setShowCastButton(bool show) async {
+    if (showCastButton == show) return;
+    showCastButton = show;
+    notifyListeners();
+    await audioRepo?.settings.saveAppearance(showCast: show);
   }
 
   Future<void> setSponsorBlock(bool enabled) async {


### PR DESCRIPTION
Four commits: gaana downloads, an offline playback fix, the on-device library, and a cluster of startup/shutdown bugs found by chasing one complaint.

## Gaana tracks are downloadable

Gaana ships HLS — a playlist of six-second MPEG-TS segments — where saavn ships a single `.m4a`, so it was refused with "HLS streams aren't downloadable yet" and the download action was hidden on every gaana row.

It needed one new file. **MPEG-TS is designed to be concatenated**, so writing the segments end to end produces a stream mpv plays directly. Verified against a real track *before* writing any app code: 55 segments appended came back from ffprobe as `mpegts, aac, 44100 Hz, stereo, 329.5s` — the complete song. No remux, no ffmpeg, **no new dependency**.

- **Highest quality always**, ignoring the stream-quality setting on purpose — that setting is about saving mobile data while streaming, and a download is a one-time cost you keep. ~200 kbps against ~83 for `medium`.
- **Progress counts segments, not bytes.** HLS has no Content-Length for the whole thing, and segments are near-uniform, so "18 of 55" is honest and smooth.
- **Encrypted playlists are refused loudly.** Gaana's carry no `EXT-X-KEY`; rather than half-implement AES-128 HLS against a provider that doesn't use it, it fails with a reason the row shows instead of writing undecryptable bytes that fail later at playback.

## Offline playback stops instead of skipping

Playing a downloaded track offline and letting it end walked the whole queue in seconds and landed on silence — the handler gave up on a track and let mpv auto-advance, and with no network every following track failed identically.

It now pauses on the track that failed, and retries on its own (5s → 10s → 20s → 30s → every minute, for about fifteen minutes). Retrying *is* how the network coming back gets noticed, so this needs **no connectivity plugin** — which matters while F-Droid inclusion is open. Pressing play resets the backoff.

## On-device library: sorting, genres, folders, search

Sort by date added, title, artist, album, duration or year, with a direction worded per field ("Newest first", not "Descending"). Persisted beside the folder rules and **not synced**, for the same reason they aren't — it describes this phone's library, not your taste.

**Album track order was wrong**, and that's a correctness fix rather than a preference. `MediaStore.TRACK` was read natively and thrown away in Dart, so an album opened from the device library listed its songs *in the order the files were copied onto the phone*. Fixed at the source so every consumer gets it — detail screen, Android Auto, "play album". Multi-disc comes free: MediaStore packs it as `disc * 1000 + track` and nobody was unpacking it.

- **Genres and Folders** tabs, which hide themselves when empty — no `GENRE` column below Android 11, and a library of loose files in one directory has nothing to browse by folder.
- **Search** — `LocalLibrary.search()` already existed with no caller and no field on screen.
- **Auto-rescan** via `ContentObserver`, debounced natively by a second: a file copy is one notification *per row*, so a folder of forty tracks would otherwise queue forty full-library scans.
- **Embedded artwork fallback** for files MediaStore indexed no album art for.

## Startup and shutdown

One report — "the saved progress comes too late" — turned into three bugs, in increasing severity:

1. **Restore awaited the network.** It did a Hive read and `prepareQueue` (which resolves a stream URL) in one method, and the UI waited on both. Split; the screen now paints from disk at **+369 ms**, 57 ms after the window appears.
2. **The position was then zeroed.** `prepareQueue` emits a track-change event before mpv loads the file, so `_applySong` ran twice for the same song and the second call wiped the position *and the guard protecting it*. Measured: `122s at +400ms, 0 at +800ms, 122 again only at +2800ms`. Re-applying the current track is no longer treated as a track change.
3. **The saved state was destroyed on every launch.** `_onHandlerQueueChanged` rebuilds the queue from mpv's playlist *as it builds* and persists each intermediate state; the restore guard was released when `prepareQueue` returned, but mpv keeps emitting. **Sixteen writes, queue growing 15 → 52, every one stamping `pos=0s` over a saved `202s`.** No visible symptom beyond "resume sometimes forgets where I was" — the worst of the three.

**Swipe-away now clears the app.** The foreground service is deliberately kept alive through a pause, so pausing on task removal wasn't enough — Android reused the cached process and restored the screen just dismissed. It now flushes state, stops the service and exits. Deliberately *not* the class's own `stop()`, which seeks to zero and would discard the position just saved.

Also: the media resumption card that outlived the app is declined by returning nothing for audio_service's `recent` root — distinct from the browsable root Android Auto uses, so the car is unaffected. A **Cast-button toggle** in Settings, on by default, staying visible while a cast is running. **Endless autoplay now defaults on.**

## Testing

173 tests pass; the analyzer reports nothing new (8 pre-existing warnings).

Verified on device: gaana download plays; album track order; startup measured from logs; the position fix confirmed by screen recording — the progress bar is present in the first rendered frame, where it previously took 3.5–4.5 seconds.

**Not verified:** the offline stall fix has not been watched with the network actually pulled — the cascade was read from the code and matches the report, but the fix itself is unexercised. The local library's genres/folders tabs and auto-rescan are built and installed but not confirmed on a real library.
