### PR TITLE
Hi-res lossless streaming, a verifiable quality tag, and an audio buffer that was never set

### DIFF
--- a/lib/api/lossless_api.dart
+++ b/lib/api/lossless_api.dart
@@ -1,0 +1,300 @@
+// Hi-res lossless stream lookup.
+//
+// sunoh-api can tell us whether a Saavn/Gaana track also exists in a lossless
+// catalog and, if so, hand back a signed CDN URL. Two things about that URL
+// shape the design here:
+//
+//   - It is served by the catalog's own CDN, not by sunoh-api, and it carries
+//     its own signature so it needs no auth header. The phone streams it
+//     directly; no audio passes through our server. It also answers Range
+//     requests, so mpv seeks in it natively.
+//   - It expires in about an hour, so it is never persisted — only held in
+//     memory alongside its expiry, the same way the YouTube tier treats its
+//     signed URLs.
+//
+// The lookup is best-effort by construction. Playback must never wait on it and
+// must never fail because of it: every path returns null instead of throwing,
+// and the request is bounded by a short timeout.
+
+import 'dart:async';
+
+import 'package:dio/dio.dart';
+import 'package:flutter/foundation.dart';
+
+import '../audio/url_refresh.dart';
+import 'dto.dart';
+
+/// Where a track's hi-res lookup has got to.
+enum LosslessLookup {
+  /// Asking the catalog. Worth showing: a cold lookup can take a moment, and
+  /// silence while it happens reads as the feature doing nothing.
+  searching,
+
+  /// The catalog had it, and the stream is hi-res.
+  found,
+
+  /// The catalog does not carry this recording, so playback fell back to the
+  /// track's own source. Not an error — most catalogues are far smaller than
+  /// the streaming ones — and the UI says so in those terms.
+  unavailable,
+}
+
+/// A lookup's state, tagged with the song it belongs to.
+///
+/// Tagged because the resolver also runs ahead of playback for the *next*
+/// track, and an untagged status would let that quietly relabel the song on
+/// screen.
+class LosslessStatus {
+  const LosslessStatus(this.songId, this.state);
+  final String songId;
+  final LosslessLookup state;
+}
+
+/// A resolved lossless stream. [url] is playable directly by mpv.
+class LosslessStream {
+  const LosslessStream({
+    required this.url,
+    required this.expiresAt,
+    this.bitDepth,
+    this.sampleRate,
+    this.sizeBytes,
+  });
+
+  final String url;
+  final DateTime expiresAt;
+  final int? bitDepth;
+  final int? sampleRate;
+  final int? sizeBytes;
+
+  /// Human-readable badge for the player UI, e.g. "24-bit / 96 kHz".
+  String? get label {
+    if (bitDepth == null || sampleRate == null) return null;
+    final khz = (sampleRate! / 1000).toStringAsFixed(1).replaceAll('.0', '');
+    return '$bitDepth-bit / $khz kHz';
+  }
+}
+
+class LosslessApi {
+  LosslessApi(this._dio);
+
+  final Dio _dio;
+
+  /// Tracks we have already asked about and been told "no".
+  ///
+  /// Without this, every play of a track the catalog does not carry would spend
+  /// the full timeout below before falling through to the lossy tier. The
+  /// server caches misses too, but this saves the round-trip entirely. Cleared
+  /// on app restart, which is the right cadence: catalog additions are rare and
+  /// a restart is a cheap way to pick them up.
+  final Set<String> _unavailable = <String>{};
+
+  /// Answers we already have, so a hit costs a round trip once per track
+  /// rather than once per play.
+  ///
+  /// The negative set above spared the misses and left the hits paying full
+  /// price — and a hit is the case that matters, since it is the one the user
+  /// chose the setting for. Replaying a track, skipping back to it, the
+  /// pre-resolve tick and the url-refresh path all reach this instead of the
+  /// network.
+  ///
+  /// Held in memory only. The URLs are signed and expire within the hour, so
+  /// persisting them would mean writing something guaranteed to be rubbish by
+  /// the next session — the same reason the resolver does not persist its own.
+  final Map<String, LosslessStream> _resolved = <String, LosslessStream>{};
+
+  /// The most recent lookup, for the UI to reflect.
+  ///
+  /// A ValueNotifier rather than a stream: there is exactly one current value,
+  /// every listener wants only the latest, and a widget can watch it without
+  /// this file knowing anything about the widget.
+  final ValueNotifier<LosslessStatus?> status = ValueNotifier<LosslessStatus?>(
+    null,
+  );
+
+  void _publish(String songId, LosslessLookup state) =>
+      status.value = LosslessStatus(songId, state);
+
+  /// Dropped a little before the stated expiry, so a URL handed to mpv has
+  /// time to be opened before the CDN stops honouring it.
+  static const Duration _expiryMargin = Duration(minutes: 2);
+
+  bool _usable(LosslessStream s) =>
+      DateTime.now().isBefore(s.expiresAt.subtract(_expiryMargin));
+
+  /// How long playback is willing to *wait* for a lossless answer.
+  ///
+  /// Three seconds: long enough for a cold match to land, chosen knowing the
+  /// cost. A track the catalog has to search for now starts hi-res on the
+  /// first play rather than the second, and the price is that a tap on play
+  /// can sit for up to three seconds before any sound.
+  ///
+  /// That price is only ever paid once per track per session, because this is
+  /// a waiting limit rather than a deadline for the request — see [_inFlight].
+  /// Giving up on the wait while letting the request finish is what makes
+  /// "cold now, hi-res next time" true; the budget decides how often "next
+  /// time" is needed at all.
+  static const Duration _budget = Duration(seconds: 3);
+
+  /// Lookups still running, keyed by song id.
+  ///
+  /// An earlier version awaited the request with `.timeout()` and nothing
+  /// else. That throws in the caller and abandons the response, so the answer
+  /// was discarded — every play of the same track started another lookup,
+  /// waited, timed out and threw the result away again. Measured on a device:
+  /// every single track timing out, forever, while the comment above claimed
+  /// they would be warm next time.
+  ///
+  /// Now the request owns itself: it populates the caches when it completes,
+  /// whether or not anyone is still waiting. The second play is instant, and
+  /// two plays at once share one request instead of racing.
+  final Map<String, Future<LosslessStream?>> _inFlight =
+      <String, Future<LosslessStream?>>{};
+
+  /// The quality badge for a track resolved this session, or null when it was
+  /// not resolved from the lossless catalog.
+  ///
+  /// Reads the cache the lookup already keeps rather than pushing state
+  /// upward, so the UI can ask without api/ knowing anything about it.
+  String? labelFor(String songId) {
+    final s = _resolved[songId];
+    return s != null && _usable(s) ? s.label : null;
+  }
+
+  /// Forget every remembered answer, e.g. after the user toggles the setting
+  /// back on — the catalog may have gained a track since it last said no.
+  void reset() {
+    _unavailable.clear();
+    _resolved.clear();
+  }
+
+  /// Start a lookup for a track nobody is playing yet.
+  ///
+  /// The reason skipping felt slow: mpv's own prefetch only opens the next
+  /// track near the end of the current one, so pressing next early always met
+  /// a cold catalog and waited out the full budget. Asking as soon as a track
+  /// starts gives the lookup a whole song's worth of time to finish, and the
+  /// skip then hits [_resolved] instead of the network.
+  ///
+  /// Fire and forget by design — nothing awaits it, failures are already
+  /// swallowed, and a duplicate call joins the in-flight request rather than
+  /// starting a second one.
+  void warm(FeedItem song, {String quality = 'auto'}) {
+    if (_unavailable.contains(song.id)) return;
+    final known = _resolved[song.id];
+    if (known != null && _usable(known)) return;
+    if (_inFlight.containsKey(song.id)) return;
+    _inFlight[song.id] = _fetch(song, quality);
+  }
+
+  /// True while a lookup for [songId] is still running, so the UI can keep
+  /// saying "looking" rather than falling back to silence when the caller
+  /// stopped waiting.
+  bool isLooking(String songId) => _inFlight.containsKey(songId);
+
+  /// Resolve a lossless stream for [song], or null when there isn't one.
+  ///
+  /// [quality] is the app's own preference string ('auto' / 'high' / 'data').
+  /// The server maps it onto a catalog format: 'data' caps at CD rate, which is
+  /// roughly 28 MB a track against roughly 96 MB at 24-bit/96 kHz.
+  Future<LosslessStream?> resolve(
+    FeedItem song, {
+    String quality = 'auto',
+  }) async {
+    if (_unavailable.contains(song.id)) {
+      _publish(song.id, LosslessLookup.unavailable);
+      return null;
+    }
+
+    final known = _resolved[song.id];
+    if (known != null) {
+      if (_usable(known)) {
+        _publish(song.id, LosslessLookup.found);
+        return known;
+      }
+      // Expired rather than absent: the catalog still has it, the signature
+      // has just aged out. Drop it and ask again.
+      _resolved.remove(song.id);
+    }
+
+    _publish(song.id, LosslessLookup.searching);
+
+    final request = _inFlight[song.id] ??= _fetch(song, quality);
+    try {
+      return await request.timeout(_budget);
+    } on TimeoutException {
+      // Not an answer. The request is still running and will fill the cache;
+      // saying "no hi-res" here would be a guess, and the wrong one often
+      // enough to make the tag worthless.
+      debugPrint('[audio] lossless still looking for ${song.id}');
+      return null;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  /// The request itself, which runs to completion regardless of who waits.
+  Future<LosslessStream?> _fetch(FeedItem song, String quality) async {
+    try {
+      final res = await _dio.post<Map<String, dynamic>>(
+        '/lossless/stream-url',
+        data: <String, dynamic>{
+          'quality': quality,
+          // Only the fields the matcher reads. FeedItem has no toJson and
+          // does not need one for this.
+          'song': <String, dynamic>{
+            'id': song.id,
+            'title': song.title,
+            'subtitle': song.subtitle,
+            'duration': song.duration,
+            'source': song.source,
+          },
+        },
+      );
+
+      final data = res.data?['data'];
+      final url = data is Map ? data['url'] as String? : null;
+      if (url == null || url.isEmpty) {
+        _unavailable.add(song.id);
+        _publish(song.id, LosslessLookup.unavailable);
+        return null;
+      }
+
+      final stream = LosslessStream(
+        url: url,
+        // Same heuristic the signed-URL parser uses, rather than a second rule
+        // for one concept: a bare fromMillisecondsSinceEpoch on a value the
+        // server happened to send in seconds lands in 1970, which reads as
+        // "already expired" and re-resolves on every single play.
+        expiresAt:
+            UrlRefreshScheduler.expiryFromNumber(data['expiresAt']) ??
+            // No expiry stated: assume the short end so the refresh scheduler
+            // re-resolves rather than trusting a URL that may already be dead.
+            DateTime.now().add(const Duration(minutes: 30)),
+        bitDepth: (data['bitDepth'] as num?)?.toInt(),
+        sampleRate: (data['sampleRate'] as num?)?.toInt(),
+        sizeBytes: (data['sizeBytes'] as num?)?.toInt(),
+      );
+      _resolved[song.id] = stream;
+      _publish(song.id, LosslessLookup.found);
+      return stream;
+    } on DioException catch (e) {
+      // 404 is the catalog saying it does not have this recording, which is a
+      // real answer worth remembering. Anything else (503, offline) is
+      // transient and must not poison the cache.
+      if (e.response?.statusCode == 404) {
+        _unavailable.add(song.id);
+        _publish(song.id, LosslessLookup.unavailable);
+      } else {
+        debugPrint(
+          '[audio] lossless lookup failed for ${song.id}: ${e.type.name}',
+        );
+      }
+      return null;
+    } catch (e) {
+      debugPrint('[audio] lossless lookup error for ${song.id}: $e');
+      return null;
+    } finally {
+      _inFlight.remove(song.id);
+    }
+  }
+}

--- a/lib/api/stream_resolver.dart
+++ b/lib/api/stream_resolver.dart
@@ -25,13 +25,17 @@ import 'package:dio/dio.dart';
 import '../audio/url_refresh.dart';
 import 'dto.dart';
 import 'local_media_channel.dart';
+import 'lossless_api.dart';
 import 'ytmusic_channel.dart';
 
 /// User stream-quality preference. `auto` and `high` both prefer the highest
 /// available variant; the distinction is reserved for the future (e.g. `auto`
 /// could become network-adaptive). `data` caps the pick at the lowest
-/// available so cellular sessions don't burn through bandwidth.
-enum StreamQuality { auto, high, data }
+/// available so cellular sessions don't burn through bandwidth. `lossless`
+/// adds a hi-res tier ahead of everything else and otherwise behaves like
+/// `high`, so a track the lossless catalog lacks still plays at best quality
+/// rather than failing.
+enum StreamQuality { auto, high, data, lossless }
 
 /// Extension point for offline / downloaded sources. Implementations live
 /// in the downloads layer (not built yet); when wired, the resolver asks
@@ -57,6 +61,11 @@ class StreamResolver {
   /// before any network tier. Defaults to null (network-only). The
   /// downloads feature will set this once it lands.
   LocalSourceProvider? localSource;
+
+  /// Hi-res lossless lookup. Set by AppState from Settings; null means the
+  /// feature is compiled in but the user has not opted in, and the tier is
+  /// skipped entirely at zero cost.
+  LosslessApi? lossless;
 
   /// In-memory resolve cache keyed by song id. Populated on every successful
   /// resolve; consulted at the top of [resolve] for non-`forceRefresh` calls.
@@ -84,16 +93,35 @@ class StreamResolver {
     StreamQuality.high => 'high',
     StreamQuality.data => 'data',
     StreamQuality.auto => 'auto',
+    // The lossy tiers have no notion of lossless; asking them for the best
+    // they have is the right fallback when the hi-res catalog comes up empty.
+    StreamQuality.lossless => 'high',
   };
+
+  /// Ask the lossless catalog about [song] ahead of time.
+  ///
+  /// No-op unless the user chose lossless. Cheap enough to call on every track
+  /// change: the API skips anything it already knows or is already fetching.
+  void warmLossless(FeedItem song) {
+    if (quality != StreamQuality.lossless) return;
+    lossless?.warm(song, quality: _qualityParam());
+  }
 
   /// Convenience setter for the Hive-persisted string form used in the UI.
   /// Unknown values fall back to `auto`.
   void setQualityFromString(String value) {
+    final previous = quality;
     quality = switch (value) {
       'high' => StreamQuality.high,
       'data' => StreamQuality.data,
+      'lossless' => StreamQuality.lossless,
       _ => StreamQuality.auto,
     };
+    // Cached URLs were resolved at the old quality, and the cache is keyed by
+    // song id alone. Without this, turning Lossless on and pressing play on
+    // anything heard this session serves the lossy URL still sitting in the
+    // cache — and the setting looks broken.
+    if (quality != previous) _cache.clear();
   }
 
   /// Returns a playable URL for [song], or throws [StreamResolveException]
@@ -151,7 +179,43 @@ class StreamResolver {
       return ResolvedStream(path);
     }
 
-    // 0b) YouTube Music. Resolved natively (see lib/api/ytmusic_channel.dart
+    // 0b) A cached answer, before any tier that would go to the network.
+    //
+    //     Hoisted above the lossless and YouTube tiers rather than left at 1a:
+    //     both of those return unconditionally, so with the check further down
+    //     a track already resolved this session still paid a full round trip
+    //     to be told what the cache already held. On the on_load hook, the
+    //     pre-resolve tick and the Cast path, that is up to a second of
+    //     silence for nothing.
+    //
+    //     forceRefresh drops the entry instead — that path exists precisely
+    //     because the cached URL is suspected dead.
+    if (forceRefresh) {
+      _cache.remove(song.id);
+    } else {
+      final cached = _cache[song.id];
+      if (cached != null && !_isStale(cached)) return cached.stream;
+      if (cached != null) _cache.remove(song.id);
+    }
+
+    // 0c) Hi-res lossless, when chosen. Ahead of BOTH the YouTube and
+    //     inline-`mediaUrls` tiers because each of those returns
+    //     unconditionally — reaching either first would mean a track that
+    //     exists in hi-res never plays in hi-res, and the setting is global
+    //     so YouTube cannot be the exception. Non-throwing and time-bounded:
+    //     a miss falls through and plays from the song's own source.
+    //
+    //     LosslessApi answers from its own memory for anything looked up this
+    //     session, hit or miss, so this is a network call once per track.
+    final ll = lossless;
+    if (quality == StreamQuality.lossless && ll != null) {
+      final hit = await ll.resolve(song, quality: _qualityParam());
+      if (hit != null) {
+        return _store(song.id, ResolvedStream(hit.url), expiry: hit.expiresAt);
+      }
+    }
+
+    // 0d) YouTube Music. Resolved natively (see lib/api/ytmusic_channel.dart
     //     for why it can't be done from Dart) and never cached here — the
     //     native side owns client selection and PO-token lifetime, and its
     //     URLs carry their own expiry which we surface to the refresh
@@ -170,23 +234,9 @@ class StreamResolver {
       return ResolvedStream(yt.url, httpHeaders: yt.headers);
     }
 
-    if (forceRefresh) {
-      // Stale-URL recovery path — drop any cached entry so the in-flight
-      // pre-resolve from a prior tick can't return a known-bad URL.
-      _cache.remove(song.id);
-    } else {
-      // 1a) Resolver cache hit (if still fresh) — populated by an earlier
-      //     resolve. Returns synchronously so the on_load hook is fast.
-      final cached = _cache[song.id];
-      if (cached != null && !_isStale(cached)) {
-        return cached.stream;
-      }
-      if (cached != null) {
-        // Cached URL is too close to expiry — drop it and re-resolve.
-        _cache.remove(song.id);
-      }
-
-      // 1b) Inline mediaUrls (fresh API responses include these).
+    // 1) Inline mediaUrls (fresh API responses include these). The cache was
+    //    consulted at 0b, above the network tiers.
+    if (!forceRefresh) {
       final embedded = _pick(song.mediaUrls);
       if (embedded != null) {
         return _store(song.id, ResolvedStream(embedded));
@@ -271,10 +321,16 @@ class StreamResolver {
     );
   }
 
-  ResolvedStream _store(String songId, ResolvedStream stream) {
+  /// [expiry] wins when the caller already knows it from the API response;
+  /// otherwise it is parsed back out of the signed URL.
+  ResolvedStream _store(
+    String songId,
+    ResolvedStream stream, {
+    DateTime? expiry,
+  }) {
     _cache[songId] = _CacheEntry(
       stream: stream,
-      expiry: UrlRefreshScheduler.parseExpiry(stream.url),
+      expiry: expiry ?? UrlRefreshScheduler.parseExpiry(stream.url),
     );
     return stream;
   }
@@ -315,8 +371,10 @@ class StreamResolver {
     return switch (quality) {
       // Cell-data saver: lowest available variant.
       StreamQuality.data => sorted.last.link,
-      // Default + 'high': highest available variant.
-      StreamQuality.auto || StreamQuality.high => sorted.first.link,
+      // Default, 'high', and the lossless fallback: highest available.
+      StreamQuality.auto ||
+      StreamQuality.high ||
+      StreamQuality.lossless => sorted.first.link,
     };
   }
 

--- a/lib/audio/audio_handler.dart
+++ b/lib/audio/audio_handler.dart
@@ -311,6 +311,21 @@ class SunohAudioHandler {
     _subs.add(_player.stream.error.listen(_onError));
     _subs.add(_player.stream.log.listen(_onLog));
     _subs.add(_player.stream.hook.listen(_onHook));
+    // What is actually being decoded, and what actually reaches the hardware.
+    // The two are not the same thing on Android — see [audioFormatLine].
+    _subs.add(
+      _player.stream.audioParams.listen((p) {
+        _decoded = p;
+        decodedNotifier.value = p;
+        _logAudioFormat();
+      }),
+    );
+    _subs.add(
+      _player.stream.audioOutParams.listen((p) {
+        _output = p;
+        _logAudioFormat();
+      }),
+    );
     // URL refresh cancels itself whenever the active track changes.
     _subs.add(currentSongStream.listen((_) => _urlRefresh.cancel()));
   }
@@ -461,10 +476,48 @@ class SunohAudioHandler {
       await _player.setRawProperty('cache', 'yes');
       await _player.setRawProperty('cache-secs', '240');
       await _player.setRawProperty('demuxer-readahead-secs', '240');
+      // ── Byte caps, raised for lossless. ──────────────────────────────
+      // cache-secs asks for four minutes; the byte cap decides whether it
+      // gets them. A lossy stream is ~40 kB/s, so 240 s is ~10 MB and never
+      // came close to any limit. A 24-bit/96 kHz FLAC is closer to 500 kB/s —
+      // the same four minutes is ~120 MB, which runs straight into mpv's
+      // default cap and silently leaves the runway far shorter than asked
+      // for, on exactly the format that can least afford a refill mid-track.
+      //
+      // A cap, not an allocation: a lossy track still holds its ~10 MB.
+      await _player.setRawProperty('demuxer-max-bytes', '192MiB');
+      // Backwards cache, so a scrub back a few seconds replays from memory
+      // instead of re-fetching a range of a large file.
+      await _player.setRawProperty('demuxer-max-back-bytes', '48MiB');
+      // ── The audio device's own runway. ───────────────────────────────
+      // Separate from the cache above, which guards the *network*. This
+      // guards the gap between mpv's decoder and Android's AudioTrack, and
+      // it was never being set: the log below claimed 500ms while the code
+      // set nothing, leaving mpv's 200ms default. Underruns followed —
+      // "Audio device underrun detected" in mpv's own log, on a 500 Mbps
+      // connection, which is nothing to do with bandwidth.
+      //
+      // 200ms is thin for what this app asks of a phone. FLAC costs more to
+      // decode than AAC, every stream is resampled to the device rate on the
+      // way out, and both compete with a Flutter UI on a mid-range CPU. One
+      // second absorbs a scheduling hiccup without being enough latency to
+      // feel on pause or seek.
+      await _player.setRawProperty('audio-buffer', '1.0');
+      // Read back rather than trust the write. `audio-buffer` is an option,
+      // not a live property: mpv accepts it at any time but only honours it
+      // when the audio output is next initialised, and a silently-ignored
+      // write here would leave the 200ms default in place while the log
+      // claimed otherwise — which is exactly the trap the previous version of
+      // this line fell into.
+      final applied = await Future.wait([
+        _player.getRawProperty('audio-buffer'),
+        _player.getRawProperty('demuxer-max-bytes'),
+        _player.getRawProperty('cache-secs'),
+      ]);
       // ignore: avoid_print
       print(
-        '[audio] tuning applied: gapless=yes prefetch-playlist=yes '
-        'audio-buffer=500ms cache-secs=240 readahead-secs=240',
+        '[audio] tuning readback: audio-buffer=${applied[0]} '
+        'demuxer-max-bytes=${applied[1]} cache-secs=${applied[2]}',
       );
     } catch (e) {
       // ignore: avoid_print
@@ -517,6 +570,60 @@ class SunohAudioHandler {
         '(mpv will auto-advance)',
       );
     }
+  }
+
+  AudioParams? _decoded;
+  AudioParams? _output;
+
+  /// Fires when the decoder reports a new format.
+  ///
+  /// A plain field was not enough: the quality tag is derived from this, and
+  /// nothing else in the app rebuilds when mpv gets round to announcing what
+  /// it opened — which happens a second or two after the track changes. The
+  /// tag would have shown the previous track's answer until something else
+  /// happened to repaint.
+  final ValueNotifier<AudioParams?> decodedNotifier =
+      ValueNotifier<AudioParams?>(null);
+
+  /// What mpv opened: the decoder's own view of the file.
+  AudioParams? get decodedParams => _decoded;
+
+  /// What the audio device was actually configured for.
+  ///
+  /// Worth having separately from [decodedParams] because Android will happily
+  /// accept a 96 kHz stream and open its AudioTrack at 48 kHz, resampling on
+  /// the way. A player that reported "24-bit / 96 kHz" off the decoder alone
+  /// would be telling the truth about the file and a lie about the sound.
+  AudioParams? get outputParams => _output;
+
+  String? _lastFormatLine;
+
+  /// One line describing the whole chain, logged when either end changes.
+  ///
+  /// This is the answer to "how do I know lossless is actually playing": not
+  /// the badge, which only reflects what the resolver chose, but what the
+  /// decoder and the audio device each report.
+  void _logAudioFormat() {
+    final line = audioFormatLine;
+    if (line == null || line == _lastFormatLine) return;
+    _lastFormatLine = line;
+    debugPrint('[audio] $line');
+  }
+
+  /// e.g. `flac 96000 Hz s32 -> out 48000 Hz s16 (resampled)`.
+  String? get audioFormatLine {
+    final d = _decoded;
+    if (d == null || d.sampleRate == null) return null;
+    final codec = (d.codecName ?? d.codec ?? '?').toLowerCase();
+    final out = _output;
+    final buf = StringBuffer(
+      '$codec ${d.sampleRate} Hz ${d.format?.name ?? '?'}',
+    );
+    if (out?.sampleRate != null) {
+      buf.write(' -> out ${out!.sampleRate} Hz ${out.format?.name ?? '?'}');
+      if (out.sampleRate != d.sampleRate) buf.write(' (resampled)');
+    }
+    return buf.toString();
   }
 
   // Per-song-id retry counter for hard load errors.
@@ -1027,6 +1134,7 @@ class SunohAudioHandler {
   // ── Cleanup ────────────────────────────────────────────────────────────
   Future<void> dispose() async {
     _urlRefresh.dispose();
+    decodedNotifier.dispose();
     _stallRetry?.cancel();
     for (final s in _subs) {
       await s.cancel();

--- a/lib/audio/audio_repo.dart
+++ b/lib/audio/audio_repo.dart
@@ -44,6 +44,10 @@ class AudioRepo {
       // skipper degrades to "no segments" on any failure, and playback
       // must never wait on a third-party lookup.
       unawaited(sponsorBlock.onTrackChanged(song));
+      // Ask the hi-res catalog about the *next* track now, while this one has
+      // a whole song's worth of time to answer in. Without it, pressing next
+      // met a cold lookup and waited out its budget before any sound.
+      _warmNextLossless();
       // Skip while restoring — `prepareQueue` emits a currentSong event
       // before mpv has actually loaded the file, so handler.position is
       // 0 even though the SAVED state had a non-zero seek target. Writing
@@ -287,6 +291,28 @@ class AudioRepo {
       }
     } finally {
       _restoreInProgress = false;
+    }
+  }
+
+  /// How far ahead the hi-res catalog is asked to look.
+  ///
+  /// Three covers the way people actually skip — a couple of taps to get past
+  /// something, not a scroll through the whole queue. Each is one small
+  /// request, answered once and then cached for the session, so the cost is
+  /// bounded even when someone skips through an album. Going deeper would
+  /// mostly buy lookups for tracks nobody reaches.
+  static const int _kLosslessWarmAhead = 3;
+
+  /// Start the hi-res lookups for the next few tracks.
+  ///
+  /// Cheap by construction: the API skips anything it already knows, already
+  /// ruled out, or is already fetching, so this settles to nothing while a
+  /// queue plays through in order.
+  void _warmNextLossless() {
+    for (var i = 1; i <= _kLosslessWarmAhead; i++) {
+      final at = _currentIndex + i;
+      if (at < 0 || at >= _queue.length) return;
+      resolver.warmLossless(_queue[at]);
     }
   }
 

--- a/lib/audio/settings_store.dart
+++ b/lib/audio/settings_store.dart
@@ -46,7 +46,12 @@ class SavedPlayback {
     this.ytCountry,
     this.ytLanguage,
   });
-  final String? streamQuality; // 'auto' / 'high' / 'data'
+  /// 'auto' / 'high' / 'data' / 'lossless'.
+  ///
+  /// 'lossless' adds a hi-res tier ahead of the usual sources and otherwise
+  /// behaves like 'high'. Deliberately a choice rather than a default: a
+  /// 24-bit/96 kHz track is roughly 96 MB against ~10 MB for the usual stream.
+  final String? streamQuality;
   /// Persisted as the `LoopMode.name` ('off' / 'all' / 'one'). Null on
   /// fresh installs / older saves that predate this field.
   final String? repeatMode;

--- a/lib/audio/url_refresh.dart
+++ b/lib/audio/url_refresh.dart
@@ -181,6 +181,32 @@ class UrlRefreshScheduler {
     unawaited(triggerRefresh(reason: 'pre-emptive timer'));
   }
 
+  /// A timestamp from a number whose unit nobody agreed on.
+  ///
+  /// Signed URLs and JSON payloads alike carry expiry as epoch milliseconds,
+  /// epoch seconds or a plain TTL, and which one depends on whose CDN minted
+  /// it. Guessing wrong is not a rounding error: reading seconds as
+  /// milliseconds lands in 1970, which every staleness check reads as "already
+  /// expired" and re-resolves on every play.
+  ///
+  /// Null for anything outside those three shapes, which callers treat as "no
+  /// expiry stated" rather than trusting it.
+  static DateTime? expiryFromNumber(Object? value) {
+    final n = value is int
+        ? value
+        : value is num
+        ? value.toInt()
+        : int.tryParse('${value ?? ''}');
+    if (n == null) return null;
+    if (n >= 1000000000000) return DateTime.fromMillisecondsSinceEpoch(n);
+    if (n >= 1000000000) return DateTime.fromMillisecondsSinceEpoch(n * 1000);
+    // A TTL in seconds, if it is within a week.
+    if (n > 0 && n < 86400 * 7) {
+      return DateTime.now().add(Duration(seconds: n));
+    }
+    return null;
+  }
+
   /// Best-effort parser for signed-URL expiry. Tries the common query-string
   /// conventions used by Gaana/Saavn/S3/CDNs. Returns null if no expiry
   /// parameter is present or parseable. Also consumed by `StreamResolver`
@@ -191,7 +217,18 @@ class UrlRefreshScheduler {
     if (uri == null) return null;
     // Walk every query param — gaana sometimes nests the token in the path
     // segments but the readable expiry is consistently in the query.
-    for (final key in const ['expires', 'expire', 'e', 'oe', 'exp', 'ttl']) {
+    // 'etsp' is the lossless CDN's name for the same thing. Without it a
+    // signed lossless URL parses as "no expiry", which the resolver cache
+    // reads as "never stale" and would hand mpv a dead URL an hour later.
+    for (final key in const [
+      'expires',
+      'expire',
+      'e',
+      'oe',
+      'exp',
+      'ttl',
+      'etsp',
+    ]) {
       final raw = uri.queryParameters[key];
       if (raw == null || raw.isEmpty) continue;
       final n = int.tryParse(raw);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:mpv_audio_kit/mpv_audio_kit.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 import 'api/client.dart';
+import 'api/lossless_api.dart';
 import 'api/sponsorblock.dart';
 import 'api/stream_resolver.dart';
 import 'api/sunoh_api.dart';
@@ -194,7 +195,10 @@ Future<void> main() async {
   print('[audio] MpvAudioKit ready');
 
   // Phase 1: synchronous mpv setup. Playback works after this line.
-  final resolver = StreamResolver(buildSunohDio());
+  // One Dio for both: the lossless lookup talks to the same sunoh-api host and
+  // benefits from the same base URL, interceptors and timeouts.
+  final sunohDio = buildSunohDio();
+  final resolver = StreamResolver(sunohDio)..lossless = LosslessApi(sunohDio);
   // Downloads — wire the offline tier before the handler is built so any
   // restored playback queue benefits from the local file lookup on the
   // very first resolve. Failures here MUST be swallowed: the manager

--- a/lib/player/expanded_player.dart
+++ b/lib/player/expanded_player.dart
@@ -30,6 +30,7 @@ import '../router/router.dart';
 import '../state/app_state.dart';
 import '../theme/tokens.dart';
 import '../widgets/album_art.dart';
+import '../widgets/quality_tag.dart';
 import '../widgets/ui.dart';
 import 'scrubber.dart';
 
@@ -301,6 +302,12 @@ class _ExpandedPlayerState extends ConsumerState<ExpandedPlayer>
                               color: c.fgDim,
                             ),
                           ),
+                          // Directly under the artist, where the rest of the
+                          // track's metadata already lives. Renders nothing
+                          // for an ordinary lossy track, so it costs no space
+                          // when there is nothing to say.
+                          const SizedBox(height: 7),
+                          QualityTag(colors: c),
                           if (lyricLine != null) ...[
                             const SizedBox(height: 8),
                             _LyricsTeaser(

--- a/lib/player/mini_player.dart
+++ b/lib/player/mini_player.dart
@@ -11,6 +11,7 @@ import '../providers/palette_provider.dart';
 import '../router/router.dart';
 import '../theme/tokens.dart';
 import '../widgets/album_art.dart';
+import '../widgets/quality_tag.dart';
 import 'scrubber.dart';
 
 class MiniPlayer extends ConsumerWidget {
@@ -69,11 +70,26 @@ class MiniPlayer extends ConsumerWidget {
                           color: c.fg,
                         ),
                       ),
-                      Text(
-                        track.artist,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: SunohType.sans(fontSize: 11.5, color: c.fgMute),
+                      Row(
+                        children: [
+                          Flexible(
+                            child: Text(
+                              track.artist,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: SunohType.sans(
+                                fontSize: 11.5,
+                                color: c.fgMute,
+                              ),
+                            ),
+                          ),
+                          // Compact form: a HI-RES mark and nothing else. The
+                          // mini player has one line to spare and no room to
+                          // explain itself, so the full label and the
+                          // fallback copy stay in the expanded player.
+                          const SizedBox(width: 8),
+                          QualityTag(colors: c, compact: true),
+                        ],
                       ),
                     ],
                   ),

--- a/lib/router/router.dart
+++ b/lib/router/router.dart
@@ -557,7 +557,12 @@ extension SunohNav on BuildContext {
       case 'artist':
         openYtArtist(item.id, name: item.title);
       default:
-        break;
+        // Songs deliberately do not land here: playing one is the caller's
+        // job, because it needs the surrounding list to build a queue from
+        // and this extension only knows how to navigate. Logged rather than
+        // ignored — a silent `break` here is what made tapping a liked song
+        // do nothing at all, with no error to find.
+        debugPrint('[deeplink] openYtItem: nothing to open for ${item.type}');
     }
   }
 

--- a/lib/screens/library_youtube_section.dart
+++ b/lib/screens/library_youtube_section.dart
@@ -10,8 +10,10 @@
 // otherwise. The invitation lives in Settings, once.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../api/dto.dart';
+import '../providers/app_state_provider.dart';
 import '../router/router.dart';
 import '../theme/tokens.dart';
 import '../widgets/album_art.dart';
@@ -45,7 +47,11 @@ class LibraryYouTubeSection extends StatelessWidget {
             eyebrowText: 'YOUTUBE MUSIC',
             padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
           ),
-          _Strip(items: section.items, colors: colors),
+          _Strip(
+            items: section.items,
+            heading: section.heading,
+            colors: colors,
+          ),
           const SizedBox(height: 22),
         ],
       ],
@@ -53,14 +59,19 @@ class LibraryYouTubeSection extends StatelessWidget {
   }
 }
 
-class _Strip extends StatelessWidget {
-  const _Strip({required this.items, required this.colors});
+class _Strip extends ConsumerWidget {
+  const _Strip({
+    required this.items,
+    required this.heading,
+    required this.colors,
+  });
 
   final List<FeedItem> items;
+  final String heading;
   final SunohColors colors;
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     const width = 116.0;
     final shown = items.take(_kPreviewCount).toList();
     return SizedBox(
@@ -70,17 +81,39 @@ class _Strip extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 20),
         itemCount: shown.length,
         separatorBuilder: (_, _) => const SizedBox(width: 12),
-        itemBuilder: (context, i) => _Tile(item: shown[i], colors: colors),
+        itemBuilder: (context, i) => _Tile(
+          item: shown[i],
+          colors: colors,
+          // A song plays; an album, playlist or artist opens. Routing every
+          // tap through openYtItem was the bug: its default case is `break`,
+          // so tapping a liked song did nothing at all — no navigation, no
+          // playback, and nothing in the log to show for it.
+          onTap: () {
+            final item = shown[i];
+            if (item.type == 'song') {
+              ref
+                  .read(appStateProvider)
+                  .playApiQueue(
+                    items,
+                    items.indexOf(item),
+                    sourceLabel: 'YOUTUBE · $heading',
+                  );
+            } else {
+              context.openYtItem(item);
+            }
+          },
+        ),
       ),
     );
   }
 }
 
 class _Tile extends StatelessWidget {
-  const _Tile({required this.item, required this.colors});
+  const _Tile({required this.item, required this.colors, required this.onTap});
 
   final FeedItem item;
   final SunohColors colors;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -90,7 +123,7 @@ class _Tile extends StatelessWidget {
     // home feed follows, so a shelf does not change shape between tabs.
     final round = item.type == 'artist';
     return GestureDetector(
-      onTap: () => context.openYtItem(item),
+      onTap: onTap,
       behavior: HitTestBehavior.opaque,
       child: SizedBox(
         width: width,

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -98,6 +98,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                   'auto': 'Auto',
                   'high': 'High',
                   'data': 'Data saver',
+                  'lossless': 'Lossless',
                 },
                 onChange: s.setStreamQuality,
                 colors: c,
@@ -555,57 +556,78 @@ class _RadioRow<T> extends StatelessWidget {
   final Map<T, String> options;
   final ValueChanged<T> onChange;
   final SunohColors colors;
+
+  /// Past three pills the segmented control no longer fits beside a label on a
+  /// phone — the label ellipsises to "Stream q…" and the control runs to the
+  /// screen edge. Rather than have callers remember, the row stacks itself and
+  /// gives the control its own full-width line. Three-option rows (theme,
+  /// density) keep the compact inline form.
+  bool get _stacked => options.length > 3;
+
+  Widget _pill(MapEntry<T, String> e, {required bool expand}) {
+    final selected = e.key == value;
+    final pill = GestureDetector(
+      onTap: () => onChange(e.key),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        padding: EdgeInsets.symmetric(horizontal: expand ? 6 : 12, vertical: 6),
+        decoration: BoxDecoration(
+          color: selected ? colors.fg : Colors.transparent,
+          borderRadius: BorderRadius.circular(999),
+        ),
+        child: Text(
+          e.value,
+          textAlign: TextAlign.center,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: SunohType.sans(
+            fontSize: 12,
+            fontWeight: FontWeight.w500,
+            color: selected ? colors.bg : colors.fgMute,
+          ),
+        ),
+      ),
+    );
+    // Expanded shares the full width evenly once the control is on its own
+    // line, so the pills read as one segmented control rather than a huddle.
+    return expand ? Expanded(child: pill) : pill;
+  }
+
+  Widget _control({required bool expand}) => Container(
+    padding: const EdgeInsets.all(3),
+    decoration: BoxDecoration(
+      color: colors.surface,
+      borderRadius: BorderRadius.circular(999),
+      border: Border.all(color: colors.line, width: 0.5),
+    ),
+    child: Row(
+      mainAxisSize: expand ? MainAxisSize.max : MainAxisSize.min,
+      children: [for (final e in options.entries) _pill(e, expand: expand)],
+    ),
+  );
+
   @override
   Widget build(BuildContext context) {
-    final c = colors;
+    final text = Text(
+      label,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: SunohType.sans(fontSize: 14, color: colors.fgDim),
+    );
+
+    if (_stacked) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [text, const SizedBox(height: 10), _control(expand: true)],
+      );
+    }
+
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        Flexible(
-          child: Text(
-            label,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: SunohType.sans(fontSize: 14, color: c.fgDim),
-          ),
-        ),
+        Flexible(child: text),
         const SizedBox(width: 12),
-        Container(
-          padding: const EdgeInsets.all(3),
-          decoration: BoxDecoration(
-            color: c.surface,
-            borderRadius: BorderRadius.circular(999),
-            border: Border.all(color: c.line, width: 0.5),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              for (final e in options.entries)
-                GestureDetector(
-                  onTap: () => onChange(e.key),
-                  child: AnimatedContainer(
-                    duration: const Duration(milliseconds: 150),
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 12,
-                      vertical: 6,
-                    ),
-                    decoration: BoxDecoration(
-                      color: e.key == value ? c.fg : Colors.transparent,
-                      borderRadius: BorderRadius.circular(999),
-                    ),
-                    child: Text(
-                      e.value,
-                      style: SunohType.sans(
-                        fontSize: 12,
-                        fontWeight: FontWeight.w500,
-                        color: e.key == value ? c.bg : c.fgMute,
-                      ),
-                    ),
-                  ),
-                ),
-            ],
-          ),
-        ),
+        _control(expand: false),
       ],
     );
   }

--- a/lib/state/app_state.dart
+++ b/lib/state/app_state.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_chrome_cast/enums.dart';
 
 import '../api/dto.dart';
+import '../api/lossless_api.dart';
 import '../api/sunoh_api.dart';
 import '../audio/audio_repo.dart';
 import '../audio/eq_presets.dart';
@@ -1621,9 +1622,82 @@ class AppState extends ChangeNotifier with WidgetsBindingObserver {
     notifyListeners();
   }
 
+  /// What the current track's audio actually is, or null when there is
+  /// nothing worth saying.
+  ///
+  /// Two sources, each for the half it can be trusted on:
+  ///
+  ///   - **mpv decides whether it is lossless.** Its codec is ground truth —
+  ///     the file really was FLAC or it really was not. The lossless API can
+  ///     only report what it handed us, which would make the badge
+  ///     unfalsifiable and therefore useless as the one thing a listener would
+  ///     check.
+  ///   - **The catalog supplies the numbers.** mpv's `audio-params` is the
+  ///     format *after* the resampler, so it reads 48 kHz for everything on a
+  ///     device whose output runs at 48 kHz — an earlier version of this
+  ///     showed that as the file's rate, which was simply wrong.
+  ///
+  /// Lossy tracks get nothing rather than a bitrate: the question this answers
+  /// is "am I getting what I turned on", and an answer that is always present
+  /// answers nothing.
+  String? get currentQualityLabel {
+    final codec =
+        (audioRepo?.handler.decodedParams?.codecName ??
+                audioRepo?.handler.decodedParams?.codec ??
+                '')
+            .toLowerCase();
+    if (codec.isEmpty) return null;
+    const lossless = ['flac', 'alac', 'wav', 'pcm', 'ape', 'wavpack'];
+    if (!lossless.any(codec.contains)) return null;
+
+    final name = codec.contains('alac') ? 'ALAC' : codec.split(' ').first;
+    final id = currentApiSong?.id;
+    final detail = id == null
+        ? null
+        : audioRepo?.resolver.lossless?.labelFor(id);
+    return detail == null
+        ? name.toUpperCase()
+        : '${name.toUpperCase()} · $detail';
+  }
+
+  /// Everything the quality tag is derived from, as one thing to listen to.
+  ///
+  /// Two independent sources change at different moments — mpv announcing the
+  /// decoded format, and the lossless lookup moving between searching, found
+  /// and unavailable — and a widget watching only one of them shows a stale
+  /// answer whenever the other moves.
+  Listenable? get qualityListenable {
+    final repo = audioRepo;
+    if (repo == null) return null;
+    final lookup = repo.resolver.lossless?.status;
+    return Listenable.merge([repo.handler.decodedNotifier, ?lookup]);
+  }
+
+  /// Where the hi-res lookup for the current track has got to, or null when it
+  /// is not being attempted. Tagged by song id upstream, so a lookup running
+  /// ahead for the *next* track cannot relabel the one on screen.
+  LosslessLookup? get losslessLookup {
+    final api = audioRepo?.resolver.lossless;
+    final id = currentApiSong?.id;
+    if (api == null || id == null) return null;
+    // A request still in flight outranks the last published state. Playback
+    // stops waiting after a fraction of a second while the lookup carries on,
+    // and during that window the honest answer is "still looking" rather than
+    // whatever was last said about this track.
+    if (api.isLooking(id)) return LosslessLookup.searching;
+    final status = api.status.value;
+    if (status == null) return null;
+    return status.songId == id ? status.state : null;
+  }
+
   void setStreamQuality(String v) {
     streamQuality = v;
-    audioRepo?.resolver.setQualityFromString(v);
+    final resolver = audioRepo?.resolver;
+    resolver?.setQualityFromString(v);
+    // Switching back to lossless should re-ask about tracks previously
+    // answered "no": the catalog may have gained them since, and that
+    // negative cache lives only for the session.
+    if (v == 'lossless') resolver?.lossless?.reset();
     _persistPlayback();
     notifyListeners();
   }

--- a/lib/widgets/quality_tag.dart
+++ b/lib/widgets/quality_tag.dart
@@ -1,0 +1,185 @@
+// What the current track's audio actually is, and what the app is doing about
+// it.
+//
+// Three states, one slot. The point of the tag is to answer a question the
+// listener would otherwise have no way to settle: "the setting says lossless —
+// am I actually getting it?"
+//
+//   - **Looking.** A cold catalog lookup takes a moment, and silence during it
+//     reads as the feature doing nothing at all.
+//   - **Found.** Named from mpv's own decoder, so it cannot claim hi-res for a
+//     stream that is not. See AppState.currentQualityLabel.
+//   - **Not found.** Most hi-res catalogues are a fraction of the size of the
+//     streaming ones, so this is the common case and not an error. It says so
+//     in those terms, and then gets out of the way.
+//
+// Nothing is shown for a lossy track when the setting is off. A tag that is
+// always present answers nothing.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../api/lossless_api.dart';
+import '../providers/app_state_provider.dart';
+import '../theme/tokens.dart';
+
+/// How long "no hi-res" stays up before fading.
+///
+/// Long enough to read, short enough that a permanent apology does not become
+/// part of the layout. The found state has no timer — that one is worth
+/// keeping on screen.
+const Duration _kMissLinger = Duration(seconds: 6);
+
+class QualityTag extends ConsumerStatefulWidget {
+  const QualityTag({super.key, required this.colors, this.compact = false});
+
+  final SunohColors colors;
+
+  /// The mini player's variant: shorter copy, smaller type, no spinner.
+  final bool compact;
+
+  @override
+  ConsumerState<QualityTag> createState() => _QualityTagState();
+}
+
+class _QualityTagState extends ConsumerState<QualityTag> {
+  Timer? _hideMiss;
+  bool _missExpired = false;
+  String? _lastSongId;
+
+  @override
+  void dispose() {
+    _hideMiss?.cancel();
+    super.dispose();
+  }
+
+  /// Restart the linger whenever the track changes, so a new miss gets its own
+  /// six seconds rather than inheriting the previous track's expired timer.
+  void _noteSong(String? songId) {
+    if (songId == _lastSongId) return;
+    _lastSongId = songId;
+    _hideMiss?.cancel();
+    _missExpired = false;
+  }
+
+  void _startMissTimer() {
+    if (_hideMiss?.isActive ?? false) return;
+    _hideMiss = Timer(_kMissLinger, () {
+      if (mounted) setState(() => _missExpired = true);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final s = ref.watch(appStateProvider);
+    final listenable = s.qualityListenable;
+    if (listenable == null) return const SizedBox.shrink();
+    _noteSong(s.currentApiSong?.id);
+
+    return ListenableBuilder(
+      listenable: listenable,
+      builder: (context, _) {
+        final label = s.currentQualityLabel;
+        final lookup = s.losslessLookup;
+
+        // Found beats everything: if mpv says the audio is lossless, the
+        // lookup's own opinion is history.
+        if (label != null) {
+          return _Chip(
+            text: widget.compact ? 'HI-RES' : label,
+            colors: widget.colors,
+            tone: _Tone.good,
+            compact: widget.compact,
+          );
+        }
+
+        switch (lookup) {
+          case LosslessLookup.searching:
+            return _Chip(
+              text: widget.compact ? 'HI-RES…' : 'Finding hi-res…',
+              colors: widget.colors,
+              tone: _Tone.busy,
+              compact: widget.compact,
+              spinner: !widget.compact,
+            );
+          case LosslessLookup.unavailable:
+            _startMissTimer();
+            if (_missExpired || widget.compact) {
+              return const SizedBox.shrink();
+            }
+            return _Chip(
+              text: 'No hi-res for this one · standard quality',
+              colors: widget.colors,
+              tone: _Tone.quiet,
+              compact: false,
+            );
+          case null:
+          case LosslessLookup.found:
+            return const SizedBox.shrink();
+        }
+      },
+    );
+  }
+}
+
+enum _Tone { good, busy, quiet }
+
+class _Chip extends StatelessWidget {
+  const _Chip({
+    required this.text,
+    required this.colors,
+    required this.tone,
+    required this.compact,
+    this.spinner = false,
+  });
+
+  final String text;
+  final SunohColors colors;
+  final _Tone tone;
+  final bool compact;
+  final bool spinner;
+
+  @override
+  Widget build(BuildContext context) {
+    final c = colors;
+    final fg = switch (tone) {
+      _Tone.good => c.accent,
+      _Tone.busy => c.fgDim,
+      _Tone.quiet => c.fgMute,
+    };
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 220),
+      child: Row(
+        key: ValueKey('$text$compact'),
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (spinner)
+            SizedBox(
+              width: 9,
+              height: 9,
+              child: CircularProgressIndicator(strokeWidth: 1.4, color: fg),
+            )
+          else
+            Container(
+              width: 5,
+              height: 5,
+              decoration: BoxDecoration(color: fg, shape: BoxShape.circle),
+            ),
+          SizedBox(width: compact ? 5 : 7),
+          Text(
+            text,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: SunohType.mono(
+              fontSize: compact ? 8.5 : 10,
+              fontWeight: FontWeight.w600,
+              color: fg,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/url_expiry_test.dart
+++ b/test/url_expiry_test.dart
@@ -1,0 +1,66 @@
+// The unit heuristic behind every "is this URL still good?" decision.
+//
+// Worth pinning because getting it wrong is silent rather than loud: reading
+// an epoch-seconds value as milliseconds lands in 1970, every staleness check
+// then reads "already expired", and the app re-resolves on every single play
+// while appearing to work.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sunoh/audio/url_refresh.dart';
+
+void main() {
+  group('expiryFromNumber', () {
+    test('epoch milliseconds are taken as-is', () {
+      final at = UrlRefreshScheduler.expiryFromNumber(1788435705000);
+      expect(at, DateTime.fromMillisecondsSinceEpoch(1788435705000));
+    });
+
+    test('epoch seconds are scaled, not read as millis', () {
+      // The whole point: 1788435705 as millis would be January 1970.
+      final at = UrlRefreshScheduler.expiryFromNumber(1788435705)!;
+      expect(at.year, greaterThan(2020));
+      expect(at, DateTime.fromMillisecondsSinceEpoch(1788435705 * 1000));
+    });
+
+    test('a small number is a TTL from now', () {
+      final at = UrlRefreshScheduler.expiryFromNumber(3600)!;
+      final delta = at.difference(DateTime.now());
+      expect(delta.inMinutes, closeTo(60, 1));
+    });
+
+    test('a TTL beyond a week is not trusted', () {
+      // Ambiguous with a malformed timestamp, and nothing signs a URL for
+      // longer than a week — so it is better to say "no expiry stated".
+      expect(UrlRefreshScheduler.expiryFromNumber(86400 * 30), isNull);
+    });
+
+    test('nothing usable yields null rather than a guess', () {
+      expect(UrlRefreshScheduler.expiryFromNumber(null), isNull);
+      expect(UrlRefreshScheduler.expiryFromNumber('nonsense'), isNull);
+      expect(UrlRefreshScheduler.expiryFromNumber(0), isNull);
+      expect(UrlRefreshScheduler.expiryFromNumber(-5), isNull);
+    });
+
+    test('accepts the shapes JSON actually arrives in', () {
+      // num from a decoded body, and a string from a query parameter.
+      expect(UrlRefreshScheduler.expiryFromNumber(1788435705.0), isNotNull);
+      expect(UrlRefreshScheduler.expiryFromNumber('1788435705'), isNotNull);
+    });
+  });
+
+  group('parseExpiry', () {
+    test('reads the lossless CDN etsp parameter', () {
+      final at = UrlRefreshScheduler.parseExpiry(
+        'https://cdn.example/track.flac?etsp=1788435705&hmac=abc',
+      )!;
+      expect(at.year, greaterThan(2020));
+    });
+
+    test('a URL with no expiry parameter yields null', () {
+      expect(
+        UrlRefreshScheduler.parseExpiry('https://cdn.example/a.flac'),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Hi-res lossless streaming, the UI that lets you verify it, a playback stutter fix, and a dead tap in the YouTube library.

## Lossless streaming

Settings → Stream quality gains **Lossless**. A hi-res tier runs ahead of the usual sources: sunoh-api says whether a Saavn/Gaana track also exists in a lossless catalog and hands back a signed CDN URL the phone streams directly, so **no audio passes through our server**. A track the catalog lacks still plays at best available quality — the tier never throws and is time-bounded.

Verified on a device: mpv reports `flac 2ch 96000 Hz` for a matched track against `aac` for one the catalog doesn't carry.

Four bugs found by watching it run rather than reading it:

- **A timeout is not an answer.** The wait was `.timeout()` on the request, which throws in the caller and *abandons the response* — the result was discarded, so the next play started another lookup, waited, timed out and threw it away again. Measured: every track timing out forever, each paying the full budget before any sound, while the comment promised they'd be warm next time. The request now owns itself and fills the cache whether or not anyone waits.
- **The next three tracks are looked up during the current one.** mpv's prefetch opens the next demuxer only near the *end* of a track, so pressing next early always met a cold catalog. Asking ahead gives each lookup a whole song to answer in.
- **The resolver cache sat below two tiers that return unconditionally** — a track already resolved this session paid a full round trip to be told what the cache held.
- **Changing quality now clears that cache.** Keyed by song id alone, so switching to Lossless and playing anything heard this session served the lossy URL still sitting there. Fixes the same latent flaw for auto/high/data.

Expiry parsing is now shared: `expiryFromNumber` holds the epoch-ms / epoch-seconds / TTL heuristic for both signed URLs and JSON. Reading seconds as milliseconds lands in 1970, which reads as "already expired" and re-resolves on every play — silent, so it has **6 tests**.

## The quality tag

A setting the listener cannot verify is a promise, not a feature. Three states — looking, found, not found — in the player (under the artist) and mini player (compact `HI-RES`).

**Losslessness comes from mpv, the numbers from the catalog.** mpv's codec is ground truth; the API can only report what it handed us, which would make the badge unfalsifiable. But mpv's `audio-params` is the format *after* the resampler, so it reads 48 kHz for everything on a 48 kHz device — an earlier version showed that as the file's rate, which was wrong.

Nothing shows for an ordinary lossy track, so the tag's appearance is an event. "Not found" isn't written as a failure — most hi-res catalogues are a fraction of the streaming ones, so a miss is the common case — and it fades after six seconds rather than becoming a permanent apology.

## Playback stutter

Stuttering across **every** source on a 500 Mbps connection. mpv's log: `Audio device underrun detected`.

The tuning block printed `audio-buffer=500ms` and **never set it**, so mpv ran its 200 ms default. Now 1.0 s, and **read back from mpv and logged** rather than trusted — it's an option, not a live property, and a silently-ignored write would leave the default in place while the log claimed otherwise. Readback on device confirms `1.000000`.

Cache byte caps raised for lossless: `cache-secs` asks for four minutes, the byte cap decides whether it gets them. Lossy is ~40 kB/s (~10 MB) and never came near a limit; a 24/96 FLAC is ~500 kB/s (~120 MB) and ran into mpv's default — the shortest runway given to the format that can least afford a refill.

Also logs the decode-to-output chain: `flac 96000 Hz s32 -> out 48000 Hz s16 (resampled)`. **That line shows what the badge cannot**: this device's AudioTrack opens at 48 kHz/16-bit, so a 24/96 file is downsampled before it's heard. The file is lossless; the output is not hi-res. That's the phone, not the app, and worth knowing before anyone markets this as hi-res playback.

## A dead tap

Tapping a track in the YouTube library shelves did nothing — no navigation, no playback, nothing in the log. The tiles routed every tap through `openYtItem`, which handles playlist/album/artist, and a song fell into its `default: break`. Songs now play the shelf as a queue. The silent default logs instead of swallowing.

These shelves were noted as built-but-unexercised when they landed in #11; one tap would have caught it.

## Testing

181 tests pass (6 new); analyzer reports nothing new.

Verified on device: lossless resolves and plays, the tag reflects mpv's actual codec, `audio-buffer` readback confirms 1.0 s, and YouTube liked songs play.

**Not settled:** whether the stutter is fully gone. The buffer is confirmed applied, so if underruns persist the cause is elsewhere — most likely CPU contention rather than buffer size.
